### PR TITLE
Split read_bits_max in two

### DIFF
--- a/benches/bench_bits.rs
+++ b/benches/bench_bits.rs
@@ -157,7 +157,23 @@ fn read_bits_max(c: &mut Criterion) {
         b.iter(|| {
             let mut bitter = BitGet::new(&DATA[..]);
             for _ in 0..ITER {
-                black_box(bitter.read_bits_max(5, 22));
+                black_box(bitter.read_bits_max(22));
+            }
+        })
+    })
+    .with_function("read_bits_max_computed", |b| {
+        b.iter(|| {
+            let mut bitter = BitGet::new(&DATA[..]);
+            for _ in 0..ITER {
+                black_box(bitter.read_bits_max_computed(4, 22));
+            }
+        })
+    })
+    .with_function("read_bits_max_computed_unchecked", |b| {
+        b.iter(|| {
+            let mut bitter = BitGet::new(&DATA[..]);
+            for _ in 0..ITER {
+                black_box(bitter.read_bits_max_computed_unchecked(4, 22));
             }
         })
     })
@@ -165,7 +181,7 @@ fn read_bits_max(c: &mut Criterion) {
         b.iter(|| {
             let mut bitter = BitGet::new(&DATA[..]);
             for _ in 0..ITER {
-                black_box(bitter.read_bits_max_unchecked(5, 22));
+                black_box(bitter.read_bits_max_unchecked(22));
             }
         })
     });
@@ -173,6 +189,14 @@ fn read_bits_max(c: &mut Criterion) {
     c.bench("read_bits_max", bench);
 }
 
-criterion_group!(benches, bitting, eight_bits, sixtyfour_bits, remaining, read_bits_max);
+fn bit_width(c: &mut Criterion) {
+    let bench = Benchmark::new("bit_width", |b| {
+        b.iter(|| bitter::bit_width(black_box(20)))
+    });
+
+    c.bench("remaining", bench);
+}
+
+criterion_group!(benches, bitting, eight_bits, sixtyfour_bits, remaining, read_bits_max, bit_width);
 
 criterion_main!(benches);

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -57,7 +57,7 @@ fn v1_eq(data: Vec<u8>) -> bool {
 
     bits.read_u32_bits(3) == bitsv1.read_u32_bits(3)
         && bits.read_u8() == bitsv1.read_u8()
-        && bits.read_bits_max(5, 20) == bitsv1.read_bits_max(5, 20)
+        && bits.read_bits_max(20) == bitsv1.read_bits_max(5, 20)
         && bits.read_bit() == bitsv1.read_bit()
         && bits.read_bytes(3).map(|x| x.into_owned()) == bitsv1.read_bytes(3)
         && bits.read_u32_bits(13) == bitsv1.read_u32_bits(13)


### PR DESCRIPTION
The read_bits_max function is now split into two halves:

- `read_bits_max` which takes one fewer argument
- `read_bits_max_computed` which takes the same arguments but the bits
argument should now be one less.

The first justification is that

```
bits.read_bits_max(100);
```

reads better than

```
bits.read_bits_max(7, 100);
```

It's less prone to error. If one were to use the new API with the
incorrect bit width, a debug assertion will fail. Using the single
argument, `read_bits_max`, one can't call it incorrectly.

If one already has the bit width of the max value alread calculated then
use the `read_bits_max_computed` function. Keep in mind it has to
satisfy:

```
max(bit_width(max), 1) == bits + 1);
```

The new APIs and assertions fix a potential underflow when 0 is the max
to value read.