### PR TITLE
Rework read_bytes to accept mutable buffer

### DIFF
--- a/benches/bench_bits.rs
+++ b/benches/bench_bits.rs
@@ -197,6 +197,31 @@ fn bit_width(c: &mut Criterion) {
     c.bench("remaining", bench);
 }
 
-criterion_group!(benches, bitting, eight_bits, sixtyfour_bits, remaining, read_bits_max, bit_width);
+fn read_bytes(c: &mut Criterion) {
+    let bench = Benchmark::new("aligned", |b| {
+        b.iter(|| {
+            let mut buf = [0u8; 7];
+            let mut bitter = BitGet::new(&DATA[..]);
+            for _ in 0..ITER {
+                black_box(bitter.read_bytes(&mut buf));
+            }
+        })
+    })
+    .with_function("unaligned", |b| {
+        b.iter(|| {
+            let mut buf = [0u8; 7];
+            let mut bitter = BitGet::new(&DATA[..]);
+            bitter.read_bit();
+            for _ in 0..ITER {
+                black_box(bitter.read_bytes(&mut buf));
+            }
+        })
+    });
+
+    c.bench("read_bytes", bench);
+
+}
+
+criterion_group!(benches, bitting, eight_bits, sixtyfour_bits, remaining, read_bits_max, bit_width, read_bytes);
 
 criterion_main!(benches);

--- a/fuzz/fuzz_targets/fuzz_bitter.rs
+++ b/fuzz/fuzz_targets/fuzz_bitter.rs
@@ -6,17 +6,18 @@ use bitterv1;
 fuzz_target!(|data: &[u8]| {
     let mut bits = bitter::BitGet::new(data);
     let mut bitsv1 = bitterv1::BitGet::new(data);
+    let mut buf1 = [0u8; 3];
 
     let res = bits.read_u32_bits(3) == bitsv1.read_u32_bits(3) &&
         bits.read_u8() == bitsv1.read_u8() &&
         bits.read_bits_max(20) == bitsv1.read_bits_max(5, 20) &&
         bits.read_bit() == bitsv1.read_bit() &&
-        bits.read_bytes(3).map(|x| x == bitsv1.read_bytes(3).unwrap()).unwrap_or(true) &&
+        bits.read_bytes(&mut buf1) == bitsv1.read_bytes(3).is_some() &&
         bits.read_u32_bits(13) == bitsv1.read_u32_bits(13) &&
         bits.read_u8() == bitsv1.read_u8() &&
         bits.read_bits_max(20) == bitsv1.read_bits_max(5, 20) &&
         bits.read_bit() == bitsv1.read_bit() &&
-        bits.read_bytes(3).map(|x| x == bitsv1.read_bytes(3).unwrap()).unwrap_or(true) &&
+        bits.read_bytes(&mut buf1) == bitsv1.read_bytes(3).is_some() &&
         bits.read_u32_bits(13) == bitsv1.read_u32_bits(13) &&
         bits.read_u8() == bitsv1.read_u8();
 


### PR DESCRIPTION
By moving `read_bytes` to accept a mutable buffer:

- Remove all allocations (hidden or otherwise) from the API
- Increase performance (aligned benchmark improved from 12.6us to 4.3us
and unaligned improved from 29.8us to 17.8us). I was kinda shocked, I
would have thought that creating a borrowed cow of slice data would be
cheaper than copying, but it looks like that is not the case.

This is a breaking change, but hopefully it gives users a chance to
reuse allocations for performance and space improvements.

Instead of

```rust
let mut bitter = BitGet::new(&[0b1010_1010, 0b0101_0101]);
assert_eq!(
    bitter.read_bytes(2).map(|x| x.into_owned()),
    Some(vec![0b1010_1010, 0b0101_0101])
)
```

write:

```rust
let mut buf = [0u8; 2];
let mut bitter = BitGet::new(&[0b1010_1010, 0b0101_0101]);
assert!(bitter.read_bytes(&mut buf));
assert_eq!(&buf, &[0b1010_1010, 0b0101_0101]);
```

The new API should be more reminiscent of the Read trait's read method,
which also takes a mutable buffer, but instead of returning a result of
bytes read we know that either we'll fill the entire buffer or there
isn't enough data.