### PR TITLE
Introduce BigEndian and NativeEndian APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Bitter takes a slice of byte data and reads bits in a desired endian format plat
  - ✔ > 1 GB/s throughput when reading single digit sized chunks of bits
  - ✔ two APIs: one for safety and one for speed
  - ✔ zero allocations
+ - ✔ zero dependencies
  - ✔ `no_std` compatible
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Bitter takes a slice of byte data and reads bits in a desired endian format plat
 ## Example
 
 ```rust
-use bitter::{BitOrder, LittleEndianBits};
+use bitter::{BitReader, LittleEndianBits};
 let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
 assert_eq!(bitter.read_bit(), Some(true));
 assert_eq!(bitter.read_u8(), Some(0x7f));
@@ -38,7 +38,7 @@ Tips:
 Below is a demonstration of the unchecked APIs with a guard to ensure safety:
 
 ```rust
-use bitter::{BitOrder, LittleEndianBits};
+use bitter::{BitReader, LittleEndianBits};
 let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
 if bitter.has_bits_remaining(16) {
     assert_eq!(bitter.read_bit_unchecked(), true);
@@ -50,7 +50,7 @@ if bitter.has_bits_remaining(16) {
 Another guard usage:
 
 ```rust
-use bitter::{BitOrder, LittleEndianBits};
+use bitter::{BitReader, LittleEndianBits};
 let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
 if bitter.has_bits_remaining(16) {
     for _ in 0..8 {

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Bitter takes a slice of byte data and reads bits in a desired endian format plat
 ## Example
 
 ```rust
-use bitter::{BitReader, LittleEndianBits};
-let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
+use bitter::{BitReader, LittleEndianReader};
+let mut bitter = LittleEndianReader::new(&[0xff, 0x04]);
 assert_eq!(bitter.read_bit(), Some(true));
 assert_eq!(bitter.read_u8(), Some(0x7f));
 assert_eq!(bitter.read_u32_bits(7), Some(0x02));
@@ -39,8 +39,8 @@ Tips:
 Below is a demonstration of the unchecked APIs with a guard to ensure safety:
 
 ```rust
-use bitter::{BitReader, LittleEndianBits};
-let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
+use bitter::{BitReader, LittleEndianReader};
+let mut bitter = LittleEndianReader::new(&[0xff, 0x04]);
 if bitter.has_bits_remaining(16) {
     assert_eq!(bitter.read_bit_unchecked(), true);
     assert_eq!(bitter.read_u8_unchecked(), 0x7f);
@@ -51,8 +51,8 @@ if bitter.has_bits_remaining(16) {
 Another guard usage:
 
 ```rust
-use bitter::{BitReader, LittleEndianBits};
-let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
+use bitter::{BitReader, LittleEndianReader};
+let mut bitter = LittleEndianReader::new(&[0xff, 0x04]);
 if bitter.has_bits_remaining(16) {
     for _ in 0..8 {
         assert_eq!(bitter.read_bit_unchecked(), true);

--- a/README.md
+++ b/README.md
@@ -1,35 +1,45 @@
 # Bitter
 
+***Reading bits until the bitter end***
+
 ![ci](https://github.com/nickbabcock/bitter/workflows/ci/badge.svg) [![](https://docs.rs/bitter/badge.svg)](https://docs.rs/bitter) [![Version](https://img.shields.io/crates/v/bitter.svg?style=flat-square)](https://crates.io/crates/bitter)
 
-Bitter takes a slice of byte data and reads little-endian bits platform agonistically.
+Bitter takes a slice of byte data and reads bits in a desired endian format platform agonistically.
 
-There are two main APIs available: checked and unchecked functions. A checked function will
-return a `Option` that will be `None` if there is not enough bits left in the stream.
-Unchecked functions, which are denoted by having "unchecked" in their name, will exhibit
-undefined behavior if there is not enough data left, but happen to be 2x faster (your numbers
-will vary depending on use case).
+## Features
+
+ - ✔ support for little endian, big endian, and native endian formats
+ - ✔ request an arbitrary amount of bits (up to 32 bits)
+ - ✔ ergonomic requests for common data types (including `u64` / `i64`)
+ - ✔ > 5 GB/s throughput when reading large number of bits
+ - ✔ > 1 GB/s throughput when reading single digit sized chunks of bits
+ - ✔ two APIs: one for safety and one for speed
+ - ✔ zero allocations
+ - ✔ `no_std` compatible
+
+## Example
+
+```rust
+use bitter::{BitOrder, LittleEndianBits};
+let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
+assert_eq!(bitter.read_bit(), Some(true));
+assert_eq!(bitter.read_u8(), Some(0x7f));
+assert_eq!(bitter.read_u32_bits(7), Some(0x02));
+```
+
+There are two main APIs available: checked and unchecked functions. The above example uses the checked API as return types are options to designate that there wasn't sufficient data to complete the read. Unchecked APIs will exhibit
+undefined behavior if there is not enough data left, but can be significantly faster. 
 
 Tips:
 
 - Prefer checked functions for all but the most performance critical code
 - Group all unchecked functions in a single block guarded by a `has_bits_remaining` call
 
-## Example
+Below is a demonstration of the unchecked APIs with a guard to ensure safety:
 
 ```rust
-use bitter::BitGet;
-let mut bitter = BitGet::new(&[0xff, 0x04]);
-assert_eq!(bitter.read_bit(), Some(true));
-assert_eq!(bitter.read_u8(), Some(0x7f));
-assert_eq!(bitter.read_u32_bits(7), Some(0x02));
-```
-
-Below, is a demonstration of guarding against potential panics:
-
-```rust
-use bitter::BitGet;
-let mut bitter = BitGet::new(&[0xff, 0x04]);
+use bitter::{BitOrder, LittleEndianBits};
+let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
 if bitter.has_bits_remaining(16) {
     assert_eq!(bitter.read_bit_unchecked(), true);
     assert_eq!(bitter.read_u8_unchecked(), 0x7f);
@@ -40,14 +50,24 @@ if bitter.has_bits_remaining(16) {
 Another guard usage:
 
 ```rust
-use bitter::BitGet;
-let mut bitter = BitGet::new(&[0xff, 0x04]);
+use bitter::{BitOrder, LittleEndianBits};
+let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
 if bitter.has_bits_remaining(16) {
     for _ in 0..8 {
         assert_eq!(bitter.read_bit_unchecked(), true);
     }
     assert_eq!(bitter.read_u8_unchecked(), 0x04);
 }
+```
+
+### `no_std` crates
+
+This crate has a feature, `std`, that is enabled by default. To use this crate
+in a `no_std` context, add the following to your `Cargo.toml`:
+
+```toml
+[dependencies]
+bitter = { version = "x", default-features = false }
 ```
 
 ## Comparison to other libraries

--- a/benches/bench_bits.rs
+++ b/benches/bench_bits.rs
@@ -9,7 +9,7 @@ extern crate bitterv1;
 
 use bitreader::BitReader;
 use bitstream_io::{BitReader as bio_br, LE};
-use bitter::BitGet;
+use bitter::{BitOrder, LittleEndianBits};
 use bitterv1::BitGet as BitGetV1;
 use criterion::{black_box, Benchmark, Criterion, ParameterizedBenchmark, Throughput};
 use std::io::Cursor;
@@ -24,7 +24,7 @@ fn bitting(c: &mut Criterion) {
         "bitter-checked",
         |b, param| {
             b.iter(|| {
-                let mut bitter = BitGet::new(&DATA[..]);
+                let mut bitter = LittleEndianBits::new(&DATA[..]);
                 for _ in 0..ITER {
                     black_box(bitter.read_u32_bits(*param));
                 }
@@ -34,7 +34,7 @@ fn bitting(c: &mut Criterion) {
     )
     .with_function("bitter-unchecked", |b, param| {
         b.iter(|| {
-            let mut bitter = BitGet::new(&DATA[..]);
+            let mut bitter = LittleEndianBits::new(&DATA[..]);
             for _ in 0..ITER {
                 black_box(bitter.read_u32_bits_unchecked(*param));
             }
@@ -100,22 +100,22 @@ macro_rules! ben {
 fn eight_bits(c: &mut Criterion) {
     let bench = Benchmark::new(
         "bitter_arbitrary_unchecked",
-        ben!(BitGet::new(&DATA), |x: &mut BitGet| x
+        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x
             .read_u32_bits_unchecked(8)),
     )
     .with_function(
         "bitter_arbitrary_checked",
-        ben!(BitGet::new(&DATA), |x: &mut BitGet| x
+        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x
             .read_u32_bits(8)
             .unwrap()),
     )
     .with_function(
         "bitter_byte_unchecked",
-        ben!(BitGet::new(&DATA), |x: &mut BitGet| x.read_u8_unchecked()),
+        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x.read_u8_unchecked()),
     )
     .with_function(
         "bitter_byte_checked",
-        ben!(BitGet::new(&DATA), |x: &mut BitGet| x
+        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x
             .read_u8()
             .map(u32::from)),
     )
@@ -127,11 +127,11 @@ fn eight_bits(c: &mut Criterion) {
 fn sixtyfour_bits(c: &mut Criterion) {
     let bench = Benchmark::new(
         "bitter_byte_unchecked",
-        ben!(BitGet::new(&DATA), |x: &mut BitGet| x.read_u64_unchecked()),
+        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x.read_u64_unchecked()),
     )
     .with_function(
         "bitter_byte_checked",
-        ben!(BitGet::new(&DATA), |x: &mut BitGet| x.read_u64()),
+        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x.read_u64()),
     )
     .throughput(Throughput::Bytes(
         ::std::mem::size_of::<u64>() as u64 * ITER,
@@ -142,13 +142,13 @@ fn sixtyfour_bits(c: &mut Criterion) {
 
 fn remaining(c: &mut Criterion) {
     let bench = Benchmark::new("bitter_approx_bytes", |b| {
-        b.iter(|| BitGet::new(&DATA).approx_bytes_remaining())
+        b.iter(|| LittleEndianBits::new(&DATA).approx_bytes_remaining())
     })
     .with_function("bitter_has_remaining", |b| {
-        b.iter(|| BitGet::new(&DATA).has_bits_remaining(16))
+        b.iter(|| LittleEndianBits::new(&DATA).has_bits_remaining(16))
     })
     .with_function("bitter_bits_remaining", |b| {
-        b.iter(|| BitGet::new(&DATA).bits_remaining())
+        b.iter(|| LittleEndianBits::new(&DATA).bits_remaining())
     });
 
     c.bench("remaining", bench);
@@ -157,7 +157,7 @@ fn remaining(c: &mut Criterion) {
 fn read_bits_max(c: &mut Criterion) {
     let bench = Benchmark::new("read_bits_max_checked", |b| {
         b.iter(|| {
-            let mut bitter = BitGet::new(&DATA[..]);
+            let mut bitter = LittleEndianBits::new(&DATA[..]);
             for _ in 0..ITER {
                 black_box(bitter.read_bits_max(22));
             }
@@ -165,7 +165,7 @@ fn read_bits_max(c: &mut Criterion) {
     })
     .with_function("read_bits_max_computed", |b| {
         b.iter(|| {
-            let mut bitter = BitGet::new(&DATA[..]);
+            let mut bitter = LittleEndianBits::new(&DATA[..]);
             for _ in 0..ITER {
                 black_box(bitter.read_bits_max_computed(4, 22));
             }
@@ -173,7 +173,7 @@ fn read_bits_max(c: &mut Criterion) {
     })
     .with_function("read_bits_max_computed_unchecked", |b| {
         b.iter(|| {
-            let mut bitter = BitGet::new(&DATA[..]);
+            let mut bitter = LittleEndianBits::new(&DATA[..]);
             for _ in 0..ITER {
                 black_box(bitter.read_bits_max_computed_unchecked(4, 22));
             }
@@ -181,7 +181,7 @@ fn read_bits_max(c: &mut Criterion) {
     })
     .with_function("read_bits_max_unchecked", |b| {
         b.iter(|| {
-            let mut bitter = BitGet::new(&DATA[..]);
+            let mut bitter = LittleEndianBits::new(&DATA[..]);
             for _ in 0..ITER {
                 black_box(bitter.read_bits_max_unchecked(22));
             }
@@ -201,7 +201,7 @@ fn read_bytes(c: &mut Criterion) {
     let bench = Benchmark::new("aligned", |b| {
         b.iter(|| {
             let mut buf = [0u8; 7];
-            let mut bitter = BitGet::new(&DATA[..]);
+            let mut bitter = LittleEndianBits::new(&DATA[..]);
             for _ in 0..ITER {
                 black_box(bitter.read_bytes(&mut buf));
             }
@@ -210,7 +210,7 @@ fn read_bytes(c: &mut Criterion) {
     .with_function("unaligned", |b| {
         b.iter(|| {
             let mut buf = [0u8; 7];
-            let mut bitter = BitGet::new(&DATA[..]);
+            let mut bitter = LittleEndianBits::new(&DATA[..]);
             bitter.read_bit();
             for _ in 0..ITER {
                 black_box(bitter.read_bytes(&mut buf));

--- a/benches/bench_bits.rs
+++ b/benches/bench_bits.rs
@@ -111,7 +111,8 @@ fn eight_bits(c: &mut Criterion) {
     )
     .with_function(
         "bitter_byte_unchecked",
-        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x.read_u8_unchecked()),
+        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x
+            .read_u8_unchecked()),
     )
     .with_function(
         "bitter_byte_checked",
@@ -127,11 +128,13 @@ fn eight_bits(c: &mut Criterion) {
 fn sixtyfour_bits(c: &mut Criterion) {
     let bench = Benchmark::new(
         "bitter_byte_unchecked",
-        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x.read_u64_unchecked()),
+        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x
+            .read_u64_unchecked()),
     )
     .with_function(
         "bitter_byte_checked",
-        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x.read_u64()),
+        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x
+            .read_u64()),
     )
     .throughput(Throughput::Bytes(
         ::std::mem::size_of::<u64>() as u64 * ITER,

--- a/benches/bench_bits.rs
+++ b/benches/bench_bits.rs
@@ -9,7 +9,7 @@ extern crate bitterv1;
 
 use bitreader::BitReader as BR;
 use bitstream_io::{BitReader as bio_br, LE};
-use bitter::{BitReader, LittleEndianBits};
+use bitter::{BitReader, LittleEndianReader};
 use bitterv1::BitGet as BitGetV1;
 use criterion::{black_box, Benchmark, Criterion, ParameterizedBenchmark, Throughput};
 use std::io::Cursor;
@@ -24,7 +24,7 @@ fn bitting(c: &mut Criterion) {
         "bitter-checked",
         |b, param| {
             b.iter(|| {
-                let mut bitter = LittleEndianBits::new(&DATA[..]);
+                let mut bitter = LittleEndianReader::new(&DATA[..]);
                 for _ in 0..ITER {
                     black_box(bitter.read_u32_bits(*param));
                 }
@@ -34,7 +34,7 @@ fn bitting(c: &mut Criterion) {
     )
     .with_function("bitter-unchecked", |b, param| {
         b.iter(|| {
-            let mut bitter = LittleEndianBits::new(&DATA[..]);
+            let mut bitter = LittleEndianReader::new(&DATA[..]);
             for _ in 0..ITER {
                 black_box(bitter.read_u32_bits_unchecked(*param));
             }
@@ -100,23 +100,23 @@ macro_rules! ben {
 fn eight_bits(c: &mut Criterion) {
     let bench = Benchmark::new(
         "bitter_arbitrary_unchecked",
-        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x
+        ben!(LittleEndianReader::new(&DATA), |x: &mut LittleEndianReader| x
             .read_u32_bits_unchecked(8)),
     )
     .with_function(
         "bitter_arbitrary_checked",
-        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x
+        ben!(LittleEndianReader::new(&DATA), |x: &mut LittleEndianReader| x
             .read_u32_bits(8)
             .unwrap()),
     )
     .with_function(
         "bitter_byte_unchecked",
-        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x
+        ben!(LittleEndianReader::new(&DATA), |x: &mut LittleEndianReader| x
             .read_u8_unchecked()),
     )
     .with_function(
         "bitter_byte_checked",
-        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x
+        ben!(LittleEndianReader::new(&DATA), |x: &mut LittleEndianReader| x
             .read_u8()
             .map(u32::from)),
     )
@@ -128,12 +128,12 @@ fn eight_bits(c: &mut Criterion) {
 fn sixtyfour_bits(c: &mut Criterion) {
     let bench = Benchmark::new(
         "bitter_byte_unchecked",
-        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x
+        ben!(LittleEndianReader::new(&DATA), |x: &mut LittleEndianReader| x
             .read_u64_unchecked()),
     )
     .with_function(
         "bitter_byte_checked",
-        ben!(LittleEndianBits::new(&DATA), |x: &mut LittleEndianBits| x
+        ben!(LittleEndianReader::new(&DATA), |x: &mut LittleEndianReader| x
             .read_u64()),
     )
     .throughput(Throughput::Bytes(
@@ -145,13 +145,13 @@ fn sixtyfour_bits(c: &mut Criterion) {
 
 fn remaining(c: &mut Criterion) {
     let bench = Benchmark::new("bitter_approx_bytes", |b| {
-        b.iter(|| LittleEndianBits::new(&DATA).approx_bytes_remaining())
+        b.iter(|| LittleEndianReader::new(&DATA).approx_bytes_remaining())
     })
     .with_function("bitter_has_remaining", |b| {
-        b.iter(|| LittleEndianBits::new(&DATA).has_bits_remaining(16))
+        b.iter(|| LittleEndianReader::new(&DATA).has_bits_remaining(16))
     })
     .with_function("bitter_bits_remaining", |b| {
-        b.iter(|| LittleEndianBits::new(&DATA).bits_remaining())
+        b.iter(|| LittleEndianReader::new(&DATA).bits_remaining())
     });
 
     c.bench("remaining", bench);
@@ -160,7 +160,7 @@ fn remaining(c: &mut Criterion) {
 fn read_bits_max(c: &mut Criterion) {
     let bench = Benchmark::new("read_bits_max_checked", |b| {
         b.iter(|| {
-            let mut bitter = LittleEndianBits::new(&DATA[..]);
+            let mut bitter = LittleEndianReader::new(&DATA[..]);
             for _ in 0..ITER {
                 black_box(bitter.read_bits_max(22));
             }
@@ -168,7 +168,7 @@ fn read_bits_max(c: &mut Criterion) {
     })
     .with_function("read_bits_max_computed", |b| {
         b.iter(|| {
-            let mut bitter = LittleEndianBits::new(&DATA[..]);
+            let mut bitter = LittleEndianReader::new(&DATA[..]);
             for _ in 0..ITER {
                 black_box(bitter.read_bits_max_computed(4, 22));
             }
@@ -176,7 +176,7 @@ fn read_bits_max(c: &mut Criterion) {
     })
     .with_function("read_bits_max_computed_unchecked", |b| {
         b.iter(|| {
-            let mut bitter = LittleEndianBits::new(&DATA[..]);
+            let mut bitter = LittleEndianReader::new(&DATA[..]);
             for _ in 0..ITER {
                 black_box(bitter.read_bits_max_computed_unchecked(4, 22));
             }
@@ -184,7 +184,7 @@ fn read_bits_max(c: &mut Criterion) {
     })
     .with_function("read_bits_max_unchecked", |b| {
         b.iter(|| {
-            let mut bitter = LittleEndianBits::new(&DATA[..]);
+            let mut bitter = LittleEndianReader::new(&DATA[..]);
             for _ in 0..ITER {
                 black_box(bitter.read_bits_max_unchecked(22));
             }
@@ -204,7 +204,7 @@ fn read_bytes(c: &mut Criterion) {
     let bench = Benchmark::new("aligned", |b| {
         b.iter(|| {
             let mut buf = [0u8; 7];
-            let mut bitter = LittleEndianBits::new(&DATA[..]);
+            let mut bitter = LittleEndianReader::new(&DATA[..]);
             for _ in 0..ITER {
                 black_box(bitter.read_bytes(&mut buf));
             }
@@ -213,7 +213,7 @@ fn read_bytes(c: &mut Criterion) {
     .with_function("unaligned", |b| {
         b.iter(|| {
             let mut buf = [0u8; 7];
-            let mut bitter = LittleEndianBits::new(&DATA[..]);
+            let mut bitter = LittleEndianReader::new(&DATA[..]);
             bitter.read_bit();
             for _ in 0..ITER {
                 black_box(bitter.read_bytes(&mut buf));

--- a/benches/bench_bits.rs
+++ b/benches/bench_bits.rs
@@ -7,9 +7,9 @@ extern crate criterion;
 extern crate nom;
 extern crate bitterv1;
 
-use bitreader::BitReader;
+use bitreader::{BitReader as BR};
 use bitstream_io::{BitReader as bio_br, LE};
-use bitter::{BitOrder, LittleEndianBits};
+use bitter::{BitReader, LittleEndianBits};
 use bitterv1::BitGet as BitGetV1;
 use criterion::{black_box, Benchmark, Criterion, ParameterizedBenchmark, Throughput};
 use std::io::Cursor;
@@ -50,7 +50,7 @@ fn bitting(c: &mut Criterion) {
     })
     .with_function("bitreader", |b, param| {
         b.iter(|| {
-            let mut bitter = BitReader::new(&DATA);
+            let mut bitter = BR::new(&DATA);
             for _ in 0..ITER {
                 black_box(bitter.read_u32(*param as u8).unwrap());
             }

--- a/benches/bench_bits.rs
+++ b/benches/bench_bits.rs
@@ -7,7 +7,7 @@ extern crate criterion;
 extern crate nom;
 extern crate bitterv1;
 
-use bitreader::{BitReader as BR};
+use bitreader::BitReader as BR;
 use bitstream_io::{BitReader as bio_br, LE};
 use bitter::{BitReader, LittleEndianBits};
 use bitterv1::BitGet as BitGetV1;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -30,3 +30,7 @@ path = "fuzz_targets/fuzz_bitter.rs"
 [[bin]]
 name = "fuzz_simple"
 path = "fuzz_targets/fuzz_simple.rs"
+
+[[bin]]
+name = "fuzz_endian"
+path = "fuzz_targets/fuzz_endian.rs"

--- a/fuzz/fuzz_targets/fuzz_bitter.rs
+++ b/fuzz/fuzz_targets/fuzz_bitter.rs
@@ -1,6 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use bitter::{LittleEndianBits, BitOrder};
+use bitter::{LittleEndianBits, BitReader};
 
 fuzz_target!(|data: &[u8]| {
     let mut bits = LittleEndianBits::new(data);

--- a/fuzz/fuzz_targets/fuzz_bitter.rs
+++ b/fuzz/fuzz_targets/fuzz_bitter.rs
@@ -1,10 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use bitter;
-use bitterv1;
+use bitter::{LittleEndianBits, BitOrder};
 
 fuzz_target!(|data: &[u8]| {
-    let mut bits = bitter::BitGet::new(data);
+    let mut bits = LittleEndianBits::new(data);
     let mut bitsv1 = bitterv1::BitGet::new(data);
     let mut buf1 = [0u8; 3];
 

--- a/fuzz/fuzz_targets/fuzz_bitter.rs
+++ b/fuzz/fuzz_targets/fuzz_bitter.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use bitter::{LittleEndianBits, BitReader};
+use bitter::{LittleEndianReader, BitReader};
 
 fuzz_target!(|data: &[u8]| {
-    let mut bits = LittleEndianBits::new(data);
+    let mut bits = LittleEndianReader::new(data);
     let mut bitsv1 = bitterv1::BitGet::new(data);
     let mut buf1 = [0u8; 3];
 

--- a/fuzz/fuzz_targets/fuzz_endian.rs
+++ b/fuzz/fuzz_targets/fuzz_endian.rs
@@ -1,0 +1,17 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use bitter::{LittleEndianBits, BitReader, BigEndianBits};
+
+fuzz_target!(|data: &[u8]| {
+    let mut lebits = LittleEndianBits::new(data);
+    let mut bebits = BigEndianBits::new(data);
+    for &i in data {
+        assert_eq!(lebits.read_u8().unwrap(), i);
+        assert_eq!(bebits.read_u8().unwrap(), i);
+    }
+
+    assert_eq!(lebits.read_u8(), None);
+    assert_eq!(bebits.read_u8(), None);
+    assert!(lebits.is_empty());
+    assert!(bebits.is_empty());
+});

--- a/fuzz/fuzz_targets/fuzz_endian.rs
+++ b/fuzz/fuzz_targets/fuzz_endian.rs
@@ -1,10 +1,10 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use bitter::{LittleEndianBits, BitReader, BigEndianBits};
+use bitter::{LittleEndianReader, BitReader, BigEndianReader};
 
 fuzz_target!(|data: &[u8]| {
-    let mut lebits = LittleEndianBits::new(data);
-    let mut bebits = BigEndianBits::new(data);
+    let mut lebits = LittleEndianReader::new(data);
+    let mut bebits = BigEndianReader::new(data);
     for &i in data {
         assert_eq!(lebits.read_u8().unwrap(), i);
         assert_eq!(bebits.read_u8().unwrap(), i);

--- a/fuzz/fuzz_targets/fuzz_simple.rs
+++ b/fuzz/fuzz_targets/fuzz_simple.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use bitter;
+use bitter::{LittleEndianBits, BitOrder};
 
 fuzz_target!(|data: &[u8]| {
-    let mut bits = bitter::BitGet::new(data);
+    let mut bits = bitter::LittleEndianBits::new(data);
 
     loop {
         if bits.read_u32_bits(17).is_none() {

--- a/fuzz/fuzz_targets/fuzz_simple.rs
+++ b/fuzz/fuzz_targets/fuzz_simple.rs
@@ -1,6 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use bitter::{LittleEndianBits, BitOrder};
+use bitter::{LittleEndianBits, BitReader};
 
 fuzz_target!(|data: &[u8]| {
     let mut bits = bitter::LittleEndianBits::new(data);

--- a/fuzz/fuzz_targets/fuzz_simple.rs
+++ b/fuzz/fuzz_targets/fuzz_simple.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use bitter::{LittleEndianBits, BitReader};
+use bitter::{LittleEndianReader, BitReader};
 
 fuzz_target!(|data: &[u8]| {
-    let mut bits = bitter::LittleEndianBits::new(data);
+    let mut bits = bitter::LittleEndianReader::new(data);
 
     loop {
         if bits.read_u32_bits(17).is_none() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@
 //! ## Example
 //!
 //! ```rust
-//! use bitter::BitGet;
-//! let mut bitter = BitGet::new(&[0xff, 0x04]);
+//! use bitter::LittleEndianBits;
+//! let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
 //! assert_eq!(bitter.read_bit(), Some(true));
 //! assert_eq!(bitter.read_u8(), Some(0x7f));
 //! assert_eq!(bitter.read_u32_bits(7), Some(0x02));
@@ -24,8 +24,8 @@
 //! Below, is a demonstration of guarding against potential panics:
 //!
 //! ```rust
-//! # use bitter::BitGet;
-//! let mut bitter = BitGet::new(&[0xff, 0x04]);
+//! # use bitter::LittleEndianBits;
+//! let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
 //! if bitter.has_bits_remaining(16) {
 //!     assert_eq!(bitter.read_bit_unchecked(), true);
 //!     assert_eq!(bitter.read_u8_unchecked(), 0x7f);
@@ -39,8 +39,8 @@
 //! Another guard usage:
 //!
 //! ```rust
-//! # use bitter::BitGet;
-//! let mut bitter = BitGet::new(&[0xff, 0x04]);
+//! # use bitter::LittleEndianBits;
+//! let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
 //! if bitter.has_bits_remaining(16) {
 //!     for _ in 0..8 {
 //!         assert_eq!(bitter.read_bit_unchecked(), true);
@@ -53,6 +53,47 @@
 //! ```
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 
+pub trait BitOrder {
+    fn read_bit(&mut self) -> Option<bool>;
+    fn read_u8(&mut self) -> Option<u8>;
+    fn read_i8(&mut self) -> Option<i8>;
+    fn read_u16(&mut self) -> Option<u16>;
+    fn read_i16(&mut self) -> Option<i16>;
+    fn read_u32(&mut self) -> Option<u32>;
+    fn read_i32(&mut self) -> Option<i32>;
+    fn read_u64(&mut self) -> Option<u64>;
+    fn read_i64(&mut self) -> Option<i64>;
+    fn read_f32(&mut self) -> Option<f32>;
+    fn read_u32_bits(&mut self, bits: i32) -> Option<u32>;
+    fn read_i32_bits(&mut self, bits: i32) -> Option<i32>;
+    fn if_get<T, F>(&mut self, f: F) -> Option<Option<T>> where F: FnMut(&mut Self) -> Option<T>;
+    fn read_bytes(&mut self, buf: &mut [u8]) -> bool;
+    fn read_bits_max(&mut self, max: u32) -> Option<u32>;
+    fn read_bits_max_computed(&mut self, bits: i32, max: u32) -> Option<u32>;
+
+    fn read_bit_unchecked(&mut self) -> bool;
+    fn read_u8_unchecked(&mut self) -> u8;
+    fn read_i8_unchecked(&mut self) -> i8;
+    fn read_u16_unchecked(&mut self) -> u16;
+    fn read_i16_unchecked(&mut self) -> i16;
+    fn read_u32_unchecked(&mut self) -> u32;
+    fn read_i32_unchecked(&mut self) -> i32;
+    fn read_u64_unchecked(&mut self) -> u64;
+    fn read_i64_unchecked(&mut self) -> i64;
+    fn read_f32_unchecked(&mut self) -> f32;
+    fn read_u32_bits_unchecked(&mut self, bits: i32) -> u32;
+    fn read_i32_bits_unchecked(&mut self, bits: i32) -> i32;
+    fn if_get_unchecked<T, F>(&mut self, f: F) -> Option<T> where F: FnMut(&mut Self) -> T;
+    fn read_bits_max_unchecked(&mut self, max: u32) -> u32;
+    fn read_bits_max_computed_unchecked(&mut self, bits: i32, max: u32) -> u32;
+
+    fn approx_bytes_remaining(&self) -> usize;
+    fn bits_remaining(&self) -> Option<usize>;
+    fn has_bits_remaining(&self, bits: usize) -> bool;
+    fn is_empty(&self) -> bool;
+
+}
+
 /// Calculates the width of the input in bits
 ///
 /// ```rust
@@ -64,24 +105,19 @@ pub const fn bit_width(input: u32) -> u32 {
     (core::mem::size_of::<u32>() as u32) * 8 - input.leading_zeros()
 }
 
-/// Reads little-endian bits platform agonistically from a slice of byte data.
-pub struct BitGet<'a> {
-    /// The bit position in `current` that we are at
-    pos: usize,
-
-    /// Byte stream of data we are parsing
-    data: &'a [u8],
-
-    /// The eight bytes that current is pointing at
-    current_val: u64,
-
-    last_read: bool,
+/// Generates the bitmask for 32-bit integers (yes, even though the return type is u64)
+#[inline]
+const fn bit_mask(bits: usize) -> u64 {
+    (1 << bits) - 1
 }
+
+const BYTE_WIDTH: usize = core::mem::size_of::<u64>();
+const BIT_WIDTH: usize = BYTE_WIDTH * 8;
 
 macro_rules! gen_read {
     ($name:ident, $t:ty) => {
         #[inline]
-        pub fn $name(&mut self) -> Option<$t> {
+        fn $name(&mut self) -> Option<$t> {
             let bits = (core::mem::size_of::<$t>() * 8) as i32;
             self.read_u32_bits(bits).map(|x| x as $t)
         }
@@ -91,509 +127,528 @@ macro_rules! gen_read {
 macro_rules! gen_read_unchecked {
     ($name:ident, $t:ty) => {
         #[inline]
-        pub fn $name(&mut self) -> $t {
+        fn $name(&mut self) -> $t {
             let bits = (core::mem::size_of::<$t>() * 8) as i32;
             self.read_u32_bits_unchecked(bits) as $t
         }
     };
 }
 
-const BYTE_WIDTH: usize = core::mem::size_of::<u64>();
-const BIT_WIDTH: usize = BYTE_WIDTH * 8;
+macro_rules! generate_bitter_end {
+    ($name:ident, $which:ident) => {
+        pub struct $name<'a> {
+            /// The bit position in `current` that we are at
+            pos: usize,
 
-impl<'a> BitGet<'a> {
-    pub fn new(data: &'a [u8]) -> BitGet<'a> {
-        let mut res = BitGet {
-            pos: 0,
-            current_val: 0,
-            data,
-            last_read: false,
-        };
+            /// Byte stream of data we are parsing
+            data: &'a [u8],
 
-        res.current_val = res.read();
-        res
-    }
+            /// The eight bytes that current is pointing at
+            current_val: u64,
 
-    gen_read!(read_u8, u8);
-    gen_read!(read_i8, i8);
-    gen_read!(read_u16, u16);
-    gen_read!(read_i16, i16);
-    gen_read!(read_u32, u32);
-    gen_read!(read_i32, i32);
+            last_read: bool,
+        }
 
-    gen_read_unchecked!(read_u8_unchecked, u8);
-    gen_read_unchecked!(read_i8_unchecked, i8);
-    gen_read_unchecked!(read_u16_unchecked, u16);
-    gen_read_unchecked!(read_i16_unchecked, i16);
-    gen_read_unchecked!(read_u32_unchecked, u32);
-    gen_read_unchecked!(read_i32_unchecked, i32);
-
-    /// Generates the bitmask for 32-bit integers (yes, even though the return type is u64)
-    #[inline]
-    fn bit_mask(bits: usize) -> u64 {
-        debug_assert!(bits < core::mem::size_of::<u64>() * 8);
-        (1 << bits) - 1
-    }
-
-    /// Determines if our bit position is not byte aligned
-    #[inline]
-    fn is_mid_byte(&self) -> bool {
-        // 0x38 = 32 | 24 | 16 | 8
-        self.pos & !0x38 != 0
-    }
-
-    /// Assuming that `self.data` is pointing to data not yet seen. slurp up 8 bytes or the
-    /// rest of the data (whatever is smaller)
-    ///
-    /// Clippy lint can be unsuppressed once Clippy recognizes this pattern as correct.
-    /// https://github.com/rust-lang/rust-clippy/issues/2881
-    #[allow(clippy::cast_ptr_alignment)]
-    #[inline]
-    fn read(&mut self) -> u64 {
-        unsafe {
-            if self.data.len() >= BYTE_WIDTH {
-                core::ptr::read_unaligned(self.data.as_ptr() as *const u8 as *const u64).to_le()
-            } else {
-                let mut data: u64 = 0;
-                let len = self.data.len();
-                core::ptr::copy_nonoverlapping(
-                    self.data.as_ptr(),
-                    &mut data as *mut u64 as *mut u8,
-                    len,
-                );
-                self.last_read = true;
-                data.to_le()
+        impl<'a> $name<'a> {
+            pub fn new(data: &'a [u8]) -> Self {
+                let mut res = $name {
+                    pos: 0,
+                    current_val: 0,
+                    data,
+                    last_read: false,
+                };
+        
+                res.current_val = res.read();
+                res
             }
-        }
-    }
-
-    #[inline]
-    pub fn read_u64_unchecked(&mut self) -> u64 {
-        // While reading 64bit we can take advantage of an optimization trick not available to
-        // other reads as 64bits is the same as our cache size
-        if self.pos == 0 {
-            let result = self.current_val;
-            self.data = &self.data[BYTE_WIDTH..];
-            self.current_val = self.read();
-            result
-        } else {
-            let bts = core::mem::size_of::<u64>() * 8;
-            let little = self.current_val >> self.pos;
-            self.data = &self.data[BYTE_WIDTH..];
-            self.current_val = self.read();
-            let big = self.current_val << (bts - self.pos);
-            little + big
-        }
-    }
-
-    #[inline]
-    pub fn read_u64(&mut self) -> Option<u64> {
-        // While reading 64bit we can take advantage of an optimization trick not available to
-        // other reads as 64bits is the same as our cache size
-        if self.pos == 0 && !self.last_read {
-            let ret = self.current_val;
-            self.data = &self.data[BYTE_WIDTH..];
-            self.current_val = self.read();
-            Some(ret)
-        } else if !self.last_read {
-            let bts = core::mem::size_of::<u64>() * 8;
-            let new_data = &self.data[BYTE_WIDTH..];
-            if new_data.len() < BYTE_WIDTH && self.pos > new_data.len() * 8 {
-                None
-            } else {
-                let little = self.current_val >> self.pos;
-                self.data = new_data;
-                self.current_val = self.read();
-                let big = self.current_val << (bts - self.pos);
-                Some(little + big)
+        
+            /// Determines if our bit position is not byte aligned
+            #[inline]
+            fn is_mid_byte(&self) -> bool {
+                // 0x38 = 32 | 24 | 16 | 8
+                self.pos & !0x38 != 0
             }
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn read_i64(&mut self) -> Option<i64> {
-        self.read_u64().map(|x| x as i64)
-    }
-
-    #[inline]
-    pub fn read_i64_unchecked(&mut self) -> i64 {
-        self.read_u64_unchecked() as i64
-    }
-
-    #[inline]
-    pub fn read_u32_bits_unchecked(&mut self, bits: i32) -> u32 {
-        let bts = bits as usize;
-        let new_pos = self.pos + bts;
-        if new_pos < BIT_WIDTH {
-            let res = (self.current_val >> self.pos) & BitGet::bit_mask(bts);
-            self.pos = new_pos;
-            res as u32
-        } else {
-            let little = self.current_val >> self.pos;
-            self.data = &self.data[BYTE_WIDTH..];
-            self.current_val = self.read();
-            let left = new_pos - BIT_WIDTH;
-            let big = (self.current_val & BitGet::bit_mask(left)) << (bts - left);
-            self.pos = left;
-            (little + big) as u32
-        }
-    }
-
-    #[inline]
-    pub fn read_u32_bits(&mut self, bits: i32) -> Option<u32> {
-        let bts = bits as usize;
-        let new_pos = self.pos + bts;
-        if (!self.last_read && new_pos < BIT_WIDTH)
-            || (self.last_read && new_pos <= self.data.len() * 8)
-        {
-            let res = (self.current_val >> self.pos) & BitGet::bit_mask(bts);
-            self.pos = new_pos;
-            Some(res as u32)
-        } else if !self.last_read {
-            let new_data = &self.data[BYTE_WIDTH..];
-            let left = new_pos - BIT_WIDTH;
-            if new_data.len() < BYTE_WIDTH && left > new_data.len() * 8 {
-                None
-            } else {
-                let little = self.current_val >> self.pos;
-                self.data = new_data;
-                self.current_val = self.read();
-                let big = (self.current_val & BitGet::bit_mask(left)) << (bts - left);
-                self.pos = left;
-                Some((little + big) as u32)
-            }
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn read_i32_bits_unchecked(&mut self, bits: i32) -> i32 {
-        self.read_u32_bits_unchecked(bits) as i32
-    }
-
-    #[inline]
-    pub fn read_i32_bits(&mut self, bits: i32) -> Option<i32> {
-        self.read_u32_bits(bits).map(|x| x as i32)
-    }
-
-    /// Return approximately how many bytes are left in the bitstream. This can overestimate by one
-    /// when the bit position is non-zero. Thus it is recommended to always compare with a greater
-    /// than sign to avoid undefined behavior with unchecked reads
-    ///
-    /// ```rust
-    /// # use bitter::BitGet;
-    /// let mut bitter = BitGet::new(&[0xff]);
-    /// assert_eq!(bitter.approx_bytes_remaining(), 1);
-    /// assert!(bitter.read_bit().is_some());
-    /// assert_eq!(bitter.approx_bytes_remaining(), 1);
-    /// assert!(bitter.read_u32_bits(7).is_some());
-    /// assert_eq!(bitter.approx_bytes_remaining(), 0);
-    /// ```
-    #[inline]
-    pub fn approx_bytes_remaining(&self) -> usize {
-        self.data.len() - (self.pos >> 3)
-    }
-
-    /// Returns the exact number of bits remaining in the bitstream if the number of bits can fit
-    /// within a `usize`. For large byte slices, the calculating the number of bits can cause an
-    /// overflow, hence an `Option` is returned. See `has_bits_remaining` for a more performant and
-    /// ergonomic alternative.
-    ///
-    /// ```rust
-    /// # use bitter::BitGet;
-    /// let mut bitter = BitGet::new(&[0xff]);
-    /// assert_eq!(bitter.bits_remaining(), Some(8));
-    /// assert!(bitter.read_bit().is_some());
-    /// assert_eq!(bitter.bits_remaining(), Some(7));
-    /// assert!(bitter.read_u32_bits(7).is_some());
-    /// assert_eq!(bitter.bits_remaining(), Some(0));
-    /// ```
-    #[inline]
-    pub fn bits_remaining(&self) -> Option<usize> {
-        self.approx_bytes_remaining()
-            .checked_mul(8)
-            .map(|x| x - (self.pos & 0x7) as usize)
-    }
-
-    /// Returns true if at least `bits` number of bits are left in the stream. A more performant
-    /// and ergonomic way than `bits_remaining`.
-    ///
-    /// ```rust
-    /// # use bitter::BitGet;
-    /// let mut bitter = BitGet::new(&[0xff]);
-    /// assert!(bitter.has_bits_remaining(7));
-    /// assert!(bitter.has_bits_remaining(8));
-    /// assert!(!bitter.has_bits_remaining(9));
-    ///
-    /// assert!(bitter.read_bit().is_some());
-    /// assert!(bitter.has_bits_remaining(7));
-    /// assert!(!bitter.has_bits_remaining(8));
-    ///
-    /// assert!(bitter.read_u32_bits(7).is_some());
-    /// assert!(!bitter.has_bits_remaining(7));
-    /// assert!(bitter.has_bits_remaining(0));
-    /// ```
-    #[inline]
-    pub fn has_bits_remaining(&self, bits: usize) -> bool {
-        let bytes_requested = bits >> 3;
-        if self.data.len() > bytes_requested + BYTE_WIDTH {
-            true
-        } else {
-            let pos_bytes = self.pos >> 3;
-            let diff = self.data.len();
-            if !self.is_mid_byte() {
-                let bytes_left = diff - pos_bytes;
-                if bytes_left == bytes_requested {
-                    bits & 0x7 == 0
-                } else {
-                    bytes_left > bytes_requested
-                }
-            } else {
-                let whole_bytes_left = diff - pos_bytes - 1;
-                if whole_bytes_left == bytes_requested {
-                    (self.pos & 0x7) <= (8 - (bits & 0x7))
-                } else {
-                    whole_bytes_left > bytes_requested
+        
+            /// Assuming that `self.data` is pointing to data not yet seen. slurp up 8 bytes or the
+            /// rest of the data (whatever is smaller)
+            ///
+            /// Clippy lint can be unsuppressed once Clippy recognizes this pattern as correct.
+            /// https://github.com/rust-lang/rust-clippy/issues/2881
+            #[allow(clippy::cast_ptr_alignment)]
+            #[inline]
+            fn read(&mut self) -> u64 {
+                unsafe {
+                    if self.data.len() >= BYTE_WIDTH {
+                        core::ptr::read_unaligned(self.data.as_ptr() as *const u8 as *const u64).$which()
+                    } else {
+                        let mut data: u64 = 0;
+                        let len = self.data.len();
+                        core::ptr::copy_nonoverlapping(
+                            self.data.as_ptr(),
+                            &mut data as *mut u64 as *mut u8,
+                            len,
+                        );
+                        self.last_read = true;
+                        data.$which()
+                    }
                 }
             }
         }
-    }
-
-    /// Returns if the bitstream has no bits left
-    ///
-    /// ```rust
-    /// # use bitter::BitGet;
-    /// let mut bitter = BitGet::new(&[0b1010_1010, 0b0101_0101]);
-    /// assert_eq!(bitter.is_empty(), false);
-    /// assert_eq!(bitter.read_u16_unchecked(), 0b0101_0101_1010_1010);
-    /// assert_eq!(bitter.is_empty(), true);
-    /// ```
-    pub fn is_empty(&self) -> bool {
-        self.approx_bytes_remaining() == 0
-    }
-
-    /// Reads a bit from the bitstream if available
-    ///
-    /// ```rust
-    /// # use bitter::BitGet;
-    /// let mut bitter = BitGet::new(&[0b1010_1010, 0b0101_0101]);
-    /// assert_eq!(bitter.read_bit(), Some(false));
-    /// ```
-    #[inline]
-    pub fn read_bit(&mut self) -> Option<bool> {
-        self.read_u32_bits(1).map(|x| x != 0)
-    }
-
-    /// *Assumes* there is at least one bit left in the stream.
-    ///
-    /// ```rust
-    /// # use bitter::BitGet;
-    /// let mut bitter = BitGet::new(&[0b1010_1010, 0b0101_0101]);
-    /// assert_eq!(bitter.read_bit_unchecked(), false);
-    /// ```
-    #[inline]
-    pub fn read_bit_unchecked(&mut self) -> bool {
-        self.read_u32_bits_unchecked(1) & 1 != 0
-    }
-
-    /// Reads a `f32` from the bitstream if available. The standard IEEE-754 binary layout float is
-    /// used.
-    #[inline]
-    pub fn read_f32(&mut self) -> Option<f32> {
-        self.read_u32().map(f32::from_bits)
-    }
-
-    /// Reads a `f32` from the bitstream. The standard IEEE-754 binary layout float is used.
-    #[inline]
-    pub fn read_f32_unchecked(&mut self) -> f32 {
-        f32::from_bits(self.read_u32_unchecked())
-    }
-
-    /// If the next bit is available and on, decode the next chunk of data (which can return None).
-    /// The return value can be one of the following:
-    ///
-    /// - None: Not enough data was available
-    /// - Some(None): Bit was off so data not decoded
-    /// - Some(x): Bit was on and data was decoded
-    ///
-    /// ```rust
-    /// # use bitter::BitGet;
-    /// let mut bitter = BitGet::new(&[0xff, 0x04]);
-    /// assert_eq!(bitter.if_get(BitGet::read_u8), Some(Some(0x7f)));
-    /// assert_eq!(bitter.if_get(BitGet::read_u8), Some(None));
-    /// assert_eq!(bitter.if_get(BitGet::read_u8), None);
-    /// ```
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::option_option))]
-    pub fn if_get<T, F>(&mut self, mut f: F) -> Option<Option<T>>
-    where
-        F: FnMut(&mut Self) -> Option<T>,
-    {
-        self.read_bit()
-            .and_then(|bit| if bit { f(self).map(Some) } else { Some(None) })
-    }
-
-    /// If the next bit is available and on, decode the next chunk of data.  The return value can
-    /// be one of the following:
-    ///
-    /// - Some(None): Bit was off so data not decoded
-    /// - Some(x): Bit was on and data was decoded
-    ///
-    /// ```rust
-    /// # use bitter::BitGet;
-    /// let mut bitter = BitGet::new(&[0xff, 0x04]);
-    /// assert_eq!(bitter.if_get_unchecked(BitGet::read_u8_unchecked), Some(0x7f));
-    /// assert_eq!(bitter.if_get_unchecked(BitGet::read_u8_unchecked), None);
-    /// ```
-    /// # Panics
-    ///
-    /// Will panic if no data is left for the bit or for the data to be decoded.
-    pub fn if_get_unchecked<T, F>(&mut self, mut f: F) -> Option<T>
-    where
-        F: FnMut(&mut Self) -> T,
-    {
-        if self.read_bit_unchecked() {
-            Some(f(self))
-        } else {
-            None
-        }
-    }
-
-    /// Read the number of bytes needed to fill the provided buffer. Returns whether
-    /// the read was successful and the buffer has been filled.
-    ///
-    /// ```rust
-    /// # use bitter::BitGet;
-    /// let mut bitter = BitGet::new(&[0b1010_1010, 0b0101_0101]);
-    /// let mut buf = [0; 1];
-    /// assert_eq!(bitter.read_bit_unchecked(), false);
-    /// assert!(bitter.read_bytes(&mut buf));
-    /// assert_eq!(&buf, &[0b1101_0101]);
-    /// ```
-    pub fn read_bytes(&mut self, buf: &mut [u8]) -> bool {
-        let pos_bytes = self.pos >> 3;
-        let bytes_left = self.data.len() - pos_bytes;
-        if !self.is_mid_byte() && bytes_left >= buf.len() {
-            let end = pos_bytes + buf.len();
-            buf.copy_from_slice(&self.data[pos_bytes..end]);
-            self.data = &self.data[end..];
-            self.current_val = self.read();
-            self.pos = 0;
-            true
-        } else if bytes_left > buf.len() {
-            for b in buf.iter_mut() {
-                *b = self.read_u8_unchecked();
+            impl<'a> BitOrder for $name<'a> {
+                gen_read!(read_u8, u8);
+                gen_read!(read_i8, i8);
+                gen_read!(read_u16, u16);
+                gen_read!(read_i16, i16);
+                gen_read!(read_u32, u32);
+                gen_read!(read_i32, i32);
+            
+                gen_read_unchecked!(read_u8_unchecked, u8);
+                gen_read_unchecked!(read_i8_unchecked, i8);
+                gen_read_unchecked!(read_u16_unchecked, u16);
+                gen_read_unchecked!(read_i16_unchecked, i16);
+                gen_read_unchecked!(read_u32_unchecked, u32);
+                gen_read_unchecked!(read_i32_unchecked, i32);
+            
+            
+            
+                #[inline]
+                fn read_u64_unchecked(&mut self) -> u64 {
+                    // While reading 64bit we can take advantage of an optimization trick not available to
+                    // other reads as 64bits is the same as our cache size
+                    if self.pos == 0 {
+                        let result = self.current_val;
+                        self.data = &self.data[BYTE_WIDTH..];
+                        self.current_val = self.read();
+                        result
+                    } else {
+                        let bts = core::mem::size_of::<u64>() * 8;
+                        let little = self.current_val >> self.pos;
+                        self.data = &self.data[BYTE_WIDTH..];
+                        self.current_val = self.read();
+                        let big = self.current_val << (bts - self.pos);
+                        little + big
+                    }
+                }
+            
+                #[inline]
+                fn read_u64(&mut self) -> Option<u64> {
+                    // While reading 64bit we can take advantage of an optimization trick not available to
+                    // other reads as 64bits is the same as our cache size
+                    if self.pos == 0 && !self.last_read {
+                        let ret = self.current_val;
+                        self.data = &self.data[BYTE_WIDTH..];
+                        self.current_val = self.read();
+                        Some(ret)
+                    } else if !self.last_read {
+                        let bts = core::mem::size_of::<u64>() * 8;
+                        let new_data = &self.data[BYTE_WIDTH..];
+                        if new_data.len() < BYTE_WIDTH && self.pos > new_data.len() * 8 {
+                            None
+                        } else {
+                            let little = self.current_val >> self.pos;
+                            self.data = new_data;
+                            self.current_val = self.read();
+                            let big = self.current_val << (bts - self.pos);
+                            Some(little + big)
+                        }
+                    } else {
+                        None
+                    }
+                }
+            
+                #[inline]
+                fn read_i64(&mut self) -> Option<i64> {
+                    self.read_u64().map(|x| x as i64)
+                }
+            
+                #[inline]
+                fn read_i64_unchecked(&mut self) -> i64 {
+                    self.read_u64_unchecked() as i64
+                }
+            
+                #[inline]
+                fn read_u32_bits_unchecked(&mut self, bits: i32) -> u32 {
+                    let bts = bits as usize;
+                    let new_pos = self.pos + bts;
+                    if new_pos < BIT_WIDTH {
+                        let res = (self.current_val >> self.pos) & bit_mask(bts);
+                        self.pos = new_pos;
+                        res as u32
+                    } else {
+                        let little = self.current_val >> self.pos;
+                        self.data = &self.data[BYTE_WIDTH..];
+                        self.current_val = self.read();
+                        let left = new_pos - BIT_WIDTH;
+                        let big = (self.current_val & bit_mask(left)) << (bts - left);
+                        self.pos = left;
+                        (little + big) as u32
+                    }
+                }
+            
+                #[inline]
+                fn read_u32_bits(&mut self, bits: i32) -> Option<u32> {
+                    let bts = bits as usize;
+                    let new_pos = self.pos + bts;
+                    if (!self.last_read && new_pos < BIT_WIDTH)
+                        || (self.last_read && new_pos <= self.data.len() * 8)
+                    {
+                        let res = (self.current_val >> self.pos) & bit_mask(bts);
+                        self.pos = new_pos;
+                        Some(res as u32)
+                    } else if !self.last_read {
+                        let new_data = &self.data[BYTE_WIDTH..];
+                        let left = new_pos - BIT_WIDTH;
+                        if new_data.len() < BYTE_WIDTH && left > new_data.len() * 8 {
+                            None
+                        } else {
+                            let little = self.current_val >> self.pos;
+                            self.data = new_data;
+                            self.current_val = self.read();
+                            let big = (self.current_val & bit_mask(left)) << (bts - left);
+                            self.pos = left;
+                            Some((little + big) as u32)
+                        }
+                    } else {
+                        None
+                    }
+                }
+            
+                #[inline]
+                fn read_i32_bits_unchecked(&mut self, bits: i32) -> i32 {
+                    self.read_u32_bits_unchecked(bits) as i32
+                }
+            
+                #[inline]
+                fn read_i32_bits(&mut self, bits: i32) -> Option<i32> {
+                    self.read_u32_bits(bits).map(|x| x as i32)
+                }
+            
+                /// Return approximately how many bytes are left in the bitstream. This can overestimate by one
+                /// when the bit position is non-zero. Thus it is recommended to always compare with a greater
+                /// than sign to avoid undefined behavior with unchecked reads
+                ///
+                /// ```rust
+                /// # use bitter::LittleEndianBits;
+                /// let mut bitter = LittleEndianBits::new(&[0xff]);
+                /// assert_eq!(bitter.approx_bytes_remaining(), 1);
+                /// assert!(bitter.read_bit().is_some());
+                /// assert_eq!(bitter.approx_bytes_remaining(), 1);
+                /// assert!(bitter.read_u32_bits(7).is_some());
+                /// assert_eq!(bitter.approx_bytes_remaining(), 0);
+                /// ```
+                #[inline]
+                fn approx_bytes_remaining(&self) -> usize {
+                    self.data.len() - (self.pos >> 3)
+                }
+            
+                /// Returns the exact number of bits remaining in the bitstream if the number of bits can fit
+                /// within a `usize`. For large byte slices, the calculating the number of bits can cause an
+                /// overflow, hence an `Option` is returned. See `has_bits_remaining` for a more performant and
+                /// ergonomic alternative.
+                ///
+                /// ```rust
+                /// # use bitter::LittleEndianBits;
+                /// let mut bitter = LittleEndianBits::new(&[0xff]);
+                /// assert_eq!(bitter.bits_remaining(), Some(8));
+                /// assert!(bitter.read_bit().is_some());
+                /// assert_eq!(bitter.bits_remaining(), Some(7));
+                /// assert!(bitter.read_u32_bits(7).is_some());
+                /// assert_eq!(bitter.bits_remaining(), Some(0));
+                /// ```
+                #[inline]
+                fn bits_remaining(&self) -> Option<usize> {
+                    self.approx_bytes_remaining()
+                        .checked_mul(8)
+                        .map(|x| x - (self.pos & 0x7) as usize)
+                }
+            
+                /// Returns true if at least `bits` number of bits are left in the stream. A more performant
+                /// and ergonomic way than `bits_remaining`.
+                ///
+                /// ```rust
+                /// # use bitter::LittleEndianBits;
+                /// let mut bitter = LittleEndianBits::new(&[0xff]);
+                /// assert!(bitter.has_bits_remaining(7));
+                /// assert!(bitter.has_bits_remaining(8));
+                /// assert!(!bitter.has_bits_remaining(9));
+                ///
+                /// assert!(bitter.read_bit().is_some());
+                /// assert!(bitter.has_bits_remaining(7));
+                /// assert!(!bitter.has_bits_remaining(8));
+                ///
+                /// assert!(bitter.read_u32_bits(7).is_some());
+                /// assert!(!bitter.has_bits_remaining(7));
+                /// assert!(bitter.has_bits_remaining(0));
+                /// ```
+                #[inline]
+                fn has_bits_remaining(&self, bits: usize) -> bool {
+                    let bytes_requested = bits >> 3;
+                    if self.data.len() > bytes_requested + BYTE_WIDTH {
+                        true
+                    } else {
+                        let pos_bytes = self.pos >> 3;
+                        let diff = self.data.len();
+                        if !self.is_mid_byte() {
+                            let bytes_left = diff - pos_bytes;
+                            if bytes_left == bytes_requested {
+                                bits & 0x7 == 0
+                            } else {
+                                bytes_left > bytes_requested
+                            }
+                        } else {
+                            let whole_bytes_left = diff - pos_bytes - 1;
+                            if whole_bytes_left == bytes_requested {
+                                (self.pos & 0x7) <= (8 - (bits & 0x7))
+                            } else {
+                                whole_bytes_left > bytes_requested
+                            }
+                        }
+                    }
+                }
+            
+                /// Returns if the bitstream has no bits left
+                ///
+                /// ```rust
+                /// # use bitter::LittleEndianBits;
+                /// let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+                /// assert_eq!(bitter.is_empty(), false);
+                /// assert_eq!(bitter.read_u16_unchecked(), 0b0101_0101_1010_1010);
+                /// assert_eq!(bitter.is_empty(), true);
+                /// ```
+                fn is_empty(&self) -> bool {
+                    self.approx_bytes_remaining() == 0
+                }
+            
+                /// Reads a bit from the bitstream if available
+                ///
+                /// ```rust
+                /// # use bitter::LittleEndianBits;
+                /// let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+                /// assert_eq!(bitter.read_bit(), Some(false));
+                /// ```
+                #[inline]
+                fn read_bit(&mut self) -> Option<bool> {
+                    self.read_u32_bits(1).map(|x| x != 0)
+                }
+            
+                /// *Assumes* there is at least one bit left in the stream.
+                ///
+                /// ```rust
+                /// # use bitter::LittleEndianBits;
+                /// let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+                /// assert_eq!(bitter.read_bit_unchecked(), false);
+                /// ```
+                #[inline]
+                fn read_bit_unchecked(&mut self) -> bool {
+                    self.read_u32_bits_unchecked(1) & 1 != 0
+                }
+            
+                /// Reads a `f32` from the bitstream if available. The standard IEEE-754 binary layout float is
+                /// used.
+                #[inline]
+                fn read_f32(&mut self) -> Option<f32> {
+                    self.read_u32().map(f32::from_bits)
+                }
+            
+                /// Reads a `f32` from the bitstream. The standard IEEE-754 binary layout float is used.
+                #[inline]
+                fn read_f32_unchecked(&mut self) -> f32 {
+                    f32::from_bits(self.read_u32_unchecked())
+                }
+            
+                /// If the next bit is available and on, decode the next chunk of data (which can return None).
+                /// The return value can be one of the following:
+                ///
+                /// - None: Not enough data was available
+                /// - Some(None): Bit was off so data not decoded
+                /// - Some(x): Bit was on and data was decoded
+                ///
+                /// ```rust
+                /// # use bitter::LittleEndianBits;
+                /// let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
+                /// assert_eq!(bitter.if_get(LittleEndianBits::read_u8), Some(Some(0x7f)));
+                /// assert_eq!(bitter.if_get(LittleEndianBits::read_u8), Some(None));
+                /// assert_eq!(bitter.if_get(LittleEndianBits::read_u8), None);
+                /// ```
+                #[cfg_attr(feature = "cargo-clippy", allow(clippy::option_option))]
+                fn if_get<T, F>(&mut self, mut f: F) -> Option<Option<T>>
+                where
+                    F: FnMut(&mut Self) -> Option<T>,
+                {
+                    self.read_bit()
+                        .and_then(|bit| if bit { f(self).map(Some) } else { Some(None) })
+                }
+            
+                /// If the next bit is available and on, decode the next chunk of data.  The return value can
+                /// be one of the following:
+                ///
+                /// - Some(None): Bit was off so data not decoded
+                /// - Some(x): Bit was on and data was decoded
+                ///
+                /// ```rust
+                /// # use bitter::LittleEndianBits;
+                /// let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
+                /// assert_eq!(bitter.if_get_unchecked(LittleEndianBits::read_u8_unchecked), Some(0x7f));
+                /// assert_eq!(bitter.if_get_unchecked(LittleEndianBits::read_u8_unchecked), None);
+                /// ```
+                /// # Panics
+                ///
+                /// Will panic if no data is left for the bit or for the data to be decoded.
+                fn if_get_unchecked<T, F>(&mut self, mut f: F) -> Option<T>
+                where
+                    F: FnMut(&mut Self) -> T,
+                {
+                    if self.read_bit_unchecked() {
+                        Some(f(self))
+                    } else {
+                        None
+                    }
+                }
+            
+                /// Read the number of bytes needed to fill the provided buffer. Returns whether
+                /// the read was successful and the buffer has been filled.
+                ///
+                /// ```rust
+                /// # use bitter::LittleEndianBits;
+                /// let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+                /// let mut buf = [0; 1];
+                /// assert_eq!(bitter.read_bit_unchecked(), false);
+                /// assert!(bitter.read_bytes(&mut buf));
+                /// assert_eq!(&buf, &[0b1101_0101]);
+                /// ```
+                fn read_bytes(&mut self, buf: &mut [u8]) -> bool {
+                    let pos_bytes = self.pos >> 3;
+                    let bytes_left = self.data.len() - pos_bytes;
+                    if !self.is_mid_byte() && bytes_left >= buf.len() {
+                        let end = pos_bytes + buf.len();
+                        buf.copy_from_slice(&self.data[pos_bytes..end]);
+                        self.data = &self.data[end..];
+                        self.current_val = self.read();
+                        self.pos = 0;
+                        true
+                    } else if bytes_left > buf.len() {
+                        for b in buf.iter_mut() {
+                            *b = self.read_u8_unchecked();
+                        }
+            
+                        true
+                    } else {
+                        false
+                    }
+                }
+            
+                /// Reads a value from the stream that consumes the same or fewer number of bits of a given
+                /// max. The value read will always be less than the given max.
+                ///
+                /// For example if one wants to read a value that is less than 20, bitter will read at least
+                /// 4 bits from the stream. If the 5th bit would cause the accumulator to exceed the max, the
+                /// 5th bit is not consumed. Else the 5th bit is consumed and added to accumulator. If the
+                /// necessary number of bits are not available, `None` is returned.
+                ///
+                /// ```rust
+                /// # use bitter::LittleEndianBits;
+                /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
+                /// assert_eq!(bitter.read_bits_max(20), Some(8));
+                /// assert_eq!(bitter.read_bits_max(20), Some(15));
+                /// ```
+                #[inline]
+                fn read_bits_max(&mut self, max: u32) -> Option<u32> {
+                    let bits = bit_width(max) as i32 - 1;
+                    self.read_bits_max_computed(core::cmp::max(bits, 0), max)
+                }
+            
+                /// Same as `read_bits_max` except that this function accepts the already computed number of
+                /// bits to at least read. For instance, if 20 is the max, then 4 bits are at least needed.
+                ///
+                /// In general, prefer `read_bits_max` for ease of use
+                ///
+                /// ```rust
+                /// # use bitter::LittleEndianBits;
+                /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
+                /// assert_eq!(bitter.read_bits_max_computed(4, 20), Some(8));
+                /// assert_eq!(bitter.read_bits_max_computed(4, 20), Some(15));
+                /// ```
+                #[inline]
+                fn read_bits_max_computed(&mut self, bits: i32, max: u32) -> Option<u32> {
+                    debug_assert!(core::cmp::max(bit_width(max) as i32, 1) == bits + 1);
+                    self.read_u32_bits(bits).and_then(|data| {
+                        let up = data + (1 << bits);
+                        if up >= max {
+                            Some(data)
+                        } else {
+                            // Check the next bit
+                            self.read_bit().map(|x| if x { up } else { data })
+                        }
+                    })
+                }
+            
+                /// Reads a value from the stream that consumes the same or fewer number of bits of a given
+                /// max. The value read will always be less than the given max.
+                ///
+                /// For example if one wants to read a value that is less than 20, bitter will read at least
+                /// 4 bits from the stream. If the 5th bit would cause the accumulator to exceed the max, the
+                /// 5th bit is not consumed. Else the 5th bit is consumed and added to accumulator.
+                ///
+                /// ```rust
+                /// # use bitter::LittleEndianBits;
+                /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
+                /// assert_eq!(bitter.read_bits_max_unchecked(20), 8);
+                /// assert_eq!(bitter.read_bits_max_unchecked(20), 15);
+                /// ```
+                #[inline]
+                fn read_bits_max_unchecked(&mut self, max: u32) -> u32 {
+                    let bits = bit_width(max) as i32 - 1;
+                    self.read_bits_max_computed_unchecked(core::cmp::max(bits, 0), max)
+                }
+            
+                /// Same as `read_bits_max_unchecked` except that this function accepts the already computed
+                /// number of bits to at least read. For instance, if 20 is the max, then 4 bits are at least
+                /// needed.
+                ///
+                /// In general, prefer `read_bits_max_unchecked` for ease of use
+                ///
+                /// ```rust
+                /// # use bitter::LittleEndianBits;
+                /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
+                /// assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 8);
+                /// assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 15);
+                /// ```
+                #[inline]
+                fn read_bits_max_computed_unchecked(&mut self, bits: i32, max: u32) -> u32 {
+                    debug_assert!(core::cmp::max(bit_width(max) as i32, 1) == bits + 1);
+                    let data = self.read_u32_bits_unchecked(bits);
+            
+                    // If the next bit is on, what would our value be
+                    let up = data + (1 << bits);
+            
+                    // If we have the potential to equal or exceed max don't read the next bit, else read the
+                    // next bit
+                    if up >= max || !self.read_bit_unchecked() {
+                        data
+                    } else {
+                        up
+                    }
+                }
             }
-
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Reads a value from the stream that consumes the same or fewer number of bits of a given
-    /// max. The value read will always be less than the given max.
-    ///
-    /// For example if one wants to read a value that is less than 20, bitter will read at least
-    /// 4 bits from the stream. If the 5th bit would cause the accumulator to exceed the max, the
-    /// 5th bit is not consumed. Else the 5th bit is consumed and added to accumulator. If the
-    /// necessary number of bits are not available, `None` is returned.
-    ///
-    /// ```rust
-    /// # use bitter::BitGet;
-    /// let mut bitter = BitGet::new(&[0b1111_1000]);
-    /// assert_eq!(bitter.read_bits_max(20), Some(8));
-    /// assert_eq!(bitter.read_bits_max(20), Some(15));
-    /// ```
-    #[inline]
-    pub fn read_bits_max(&mut self, max: u32) -> Option<u32> {
-        let bits = bit_width(max) as i32 - 1;
-        self.read_bits_max_computed(core::cmp::max(bits, 0), max)
-    }
-
-    /// Same as `read_bits_max` except that this function accepts the already computed number of
-    /// bits to at least read. For instance, if 20 is the max, then 4 bits are at least needed.
-    ///
-    /// In general, prefer `read_bits_max` for ease of use
-    ///
-    /// ```rust
-    /// # use bitter::BitGet;
-    /// let mut bitter = BitGet::new(&[0b1111_1000]);
-    /// assert_eq!(bitter.read_bits_max_computed(4, 20), Some(8));
-    /// assert_eq!(bitter.read_bits_max_computed(4, 20), Some(15));
-    /// ```
-    #[inline]
-    pub fn read_bits_max_computed(&mut self, bits: i32, max: u32) -> Option<u32> {
-        debug_assert!(core::cmp::max(bit_width(max) as i32, 1) == bits + 1);
-        self.read_u32_bits(bits).and_then(|data| {
-            let up = data + (1 << bits);
-            if up >= max {
-                Some(data)
-            } else {
-                // Check the next bit
-                self.read_bit().map(|x| if x { up } else { data })
-            }
-        })
-    }
-
-    /// Reads a value from the stream that consumes the same or fewer number of bits of a given
-    /// max. The value read will always be less than the given max.
-    ///
-    /// For example if one wants to read a value that is less than 20, bitter will read at least
-    /// 4 bits from the stream. If the 5th bit would cause the accumulator to exceed the max, the
-    /// 5th bit is not consumed. Else the 5th bit is consumed and added to accumulator.
-    ///
-    /// ```rust
-    /// # use bitter::BitGet;
-    /// let mut bitter = BitGet::new(&[0b1111_1000]);
-    /// assert_eq!(bitter.read_bits_max_unchecked(20), 8);
-    /// assert_eq!(bitter.read_bits_max_unchecked(20), 15);
-    /// ```
-    #[inline]
-    pub fn read_bits_max_unchecked(&mut self, max: u32) -> u32 {
-        let bits = bit_width(max) as i32 - 1;
-        self.read_bits_max_computed_unchecked(core::cmp::max(bits, 0), max)
-    }
-
-    /// Same as `read_bits_max_unchecked` except that this function accepts the already computed
-    /// number of bits to at least read. For instance, if 20 is the max, then 4 bits are at least
-    /// needed.
-    ///
-    /// In general, prefer `read_bits_max_unchecked` for ease of use
-    ///
-    /// ```rust
-    /// # use bitter::BitGet;
-    /// let mut bitter = BitGet::new(&[0b1111_1000]);
-    /// assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 8);
-    /// assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 15);
-    /// ```
-    #[inline]
-    pub fn read_bits_max_computed_unchecked(&mut self, bits: i32, max: u32) -> u32 {
-        debug_assert!(core::cmp::max(bit_width(max) as i32, 1) == bits + 1);
-        let data = self.read_u32_bits_unchecked(bits);
-
-        // If the next bit is on, what would our value be
-        let up = data + (1 << bits);
-
-        // If we have the potential to equal or exceed max don't read the next bit, else read the
-        // next bit
-        if up >= max || !self.read_bit_unchecked() {
-            data
-        } else {
-            up
-        }
-    }
+    };
 }
+
+generate_bitter_end!(LittleEndianBits, to_le);
+generate_bitter_end!(BigEndianBits, to_be);
+
+#[cfg(target_endian = "little")]
+pub type NativeEndianBits<'a> = LittleEndianBits<'a>;
+
+#[cfg(target_endian = "big")]
+pub type NativeEndianBits<'a> = BigEndianBits<'a>;
 
 #[cfg(test)]
 mod tests {
-    use super::{bit_width, BitGet};
+    use super::{bit_width, LittleEndianBits, BitOrder};
 
     #[test]
     fn test_bit_reads() {
-        let mut bitter = BitGet::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
         assert_eq!(bitter.bits_remaining(), Some(16));
         assert_eq!(bitter.read_bit().unwrap(), false);
         assert_eq!(bitter.bits_remaining(), Some(15));
@@ -619,7 +674,7 @@ mod tests {
 
     #[test]
     fn test_bit_unchecked_reads() {
-        let mut bitter = BitGet::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
         assert_eq!(bitter.read_bit_unchecked(), false);
         assert_eq!(bitter.read_bit_unchecked(), true);
         assert_eq!(bitter.read_bit_unchecked(), false);
@@ -643,7 +698,7 @@ mod tests {
 
     #[test]
     fn test_bit_unchecked_bits_reads() {
-        let mut bitter = BitGet::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
         assert_eq!(bitter.read_u32_bits_unchecked(1), 0);
         assert_eq!(bitter.read_u32_bits_unchecked(1), 1);
         assert_eq!(bitter.read_u32_bits_unchecked(1), 0);
@@ -667,7 +722,7 @@ mod tests {
 
     #[test]
     fn test_has_remaining_bits() {
-        let mut bitter = BitGet::new(&[0xff, 0xff]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0xff]);
         assert!(bitter.has_bits_remaining(7));
         assert!(bitter.has_bits_remaining(8));
         assert!(bitter.has_bits_remaining(9));
@@ -684,7 +739,7 @@ mod tests {
 
     #[test]
     fn test_has_remaining_bits2() {
-        let mut bitter = BitGet::new(&[0xff, 0xff, 0xff, 0xff]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0xff, 0xff, 0xff]);
         assert!(bitter.read_u32_bits(31).is_some());
         assert!(!bitter.has_bits_remaining(2));
         assert!(bitter.has_bits_remaining(1));
@@ -692,7 +747,7 @@ mod tests {
 
     #[test]
     fn test_has_remaining_bits_bit_by_bit() {
-        let mut bitter = BitGet::new(&[0, 0, 0, 0, 0, 0, 0, 0]);
+        let mut bitter = LittleEndianBits::new(&[0, 0, 0, 0, 0, 0, 0, 0]);
         for _ in 0..200 {
             assert!(bitter.has_bits_remaining(1), bitter.read_bit().is_some());
         }
@@ -700,13 +755,13 @@ mod tests {
 
     #[test]
     fn test_16_bits_reads() {
-        let mut bitter = BitGet::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
         assert_eq!(bitter.read_u32_bits(16), Some(0b0101_0101_1010_1010));
     }
 
     #[test]
     fn test_bit_bits_reads() {
-        let mut bitter = BitGet::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
         assert_eq!(bitter.read_u32_bits(1), Some(0));
         assert_eq!(bitter.read_u32_bits(1), Some(1));
         assert_eq!(bitter.read_u32_bits(1), Some(0));
@@ -730,11 +785,11 @@ mod tests {
     #[test]
     fn test_read_bytes() {
         let mut buf = [0u8; 2];
-        let mut bitter = BitGet::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
         assert!(bitter.read_bytes(&mut buf));
         assert_eq!(&buf, &[0b1010_1010, 0b0101_0101]);
 
-        let mut bitter = BitGet::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
         assert_eq!(bitter.read_bit_unchecked(), false);
         assert!(!bitter.read_bytes(&mut buf));
         assert!(bitter.read_bytes(&mut buf[0..1]));
@@ -743,13 +798,13 @@ mod tests {
 
     #[test]
     fn test_read_bytes2() {
-        let mut bitter = BitGet::new(&[]);
+        let mut bitter = LittleEndianBits::new(&[]);
         assert!(bitter.read_bytes(&mut []));
     }
 
     #[test]
     fn test_read_bytes3() {
-        let mut bitter = BitGet::new(&[0, 0]);
+        let mut bitter = LittleEndianBits::new(&[0, 0]);
         let mut buf = [0u8; 1];
         assert!(bitter.read_bytes(&mut buf));
         assert_eq!(&buf, &[0]);
@@ -757,7 +812,7 @@ mod tests {
 
     #[test]
     fn test_read_bytes4() {
-        let mut bitter = BitGet::new(&[0, 120]);
+        let mut bitter = LittleEndianBits::new(&[0, 120]);
         let mut buf = [0u8; 1];
         assert!(bitter.read_bytes(&mut buf));
         assert_eq!(&buf, &[0]);
@@ -766,7 +821,7 @@ mod tests {
 
     #[test]
     fn test_read_bytes5() {
-        let mut bitter = BitGet::new(&[119, 0, 120]);
+        let mut bitter = LittleEndianBits::new(&[119, 0, 120]);
         assert_eq!(bitter.read_u32_bits_unchecked(8), 119);
         let mut buf = [0u8; 1];
         assert!(bitter.read_bytes(&mut buf));
@@ -776,7 +831,7 @@ mod tests {
 
     #[test]
     fn test_u8_reads() {
-        let mut bitter = BitGet::new(&[0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2]);
         assert_eq!(bitter.read_u8(), Some(0xff));
         assert_eq!(bitter.read_u8(), Some(0xfe));
         assert_eq!(bitter.read_u8(), Some(0xfa));
@@ -790,7 +845,7 @@ mod tests {
 
     #[test]
     fn test_u8_unchecked_reads() {
-        let mut bitter = BitGet::new(&[0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2]);
         assert_eq!(bitter.read_u8_unchecked(), 0xff);
         assert_eq!(bitter.read_u8_unchecked(), 0xfe);
         assert_eq!(bitter.read_u8_unchecked(), 0xfa);
@@ -804,7 +859,7 @@ mod tests {
 
     #[test]
     fn test_u64_reads() {
-        let mut bitter = BitGet::new(&[
+        let mut bitter = LittleEndianBits::new(&[
             0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2, 0x01, 0xff, 0xfe, 0xfa, 0xf7, 0xf5,
             0xf0, 0xb1, 0xb3,
         ]);
@@ -815,7 +870,7 @@ mod tests {
 
     #[test]
     fn test_u64_unchecked_reads() {
-        let mut bitter = BitGet::new(&[
+        let mut bitter = LittleEndianBits::new(&[
             0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2, 0x01, 0xff, 0xfe, 0xfa, 0xf7, 0xf5,
             0xf0, 0xb1, 0xb3,
         ]);
@@ -826,7 +881,7 @@ mod tests {
 
     #[test]
     fn test_i64_unchecked_reads() {
-        let mut bitter = BitGet::new(&[
+        let mut bitter = LittleEndianBits::new(&[
             0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2, 0x01, 0xff, 0xfe, 0xfa, 0xf7, 0xf5,
             0xf0, 0xb1, 0xb3,
         ]);
@@ -846,13 +901,13 @@ mod tests {
 
     #[test]
     fn test_u32_bit_read() {
-        let mut bitter = BitGet::new(&[0xff, 0x00, 0xab, 0xcd]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0x00, 0xab, 0xcd]);
         assert_eq!(bitter.read_u32_bits(32), Some(0xcdab00ff));
     }
 
     #[test]
     fn test_u32_reads() {
-        let mut bitter = BitGet::new(&[
+        let mut bitter = LittleEndianBits::new(&[
             0xff,
             0x00,
             0xab,
@@ -872,7 +927,7 @@ mod tests {
 
     #[test]
     fn test_f32_reads() {
-        let mut bitter = BitGet::new(&[
+        let mut bitter = LittleEndianBits::new(&[
             0b0111_1011,
             0b0001_0100,
             0b1010_1110,
@@ -890,7 +945,7 @@ mod tests {
 
     #[test]
     fn test_f32_unchecked_reads() {
-        let mut bitter = BitGet::new(&[
+        let mut bitter = LittleEndianBits::new(&[
             0b0111_1011,
             0b0001_0100,
             0b1010_1110,
@@ -908,7 +963,7 @@ mod tests {
 
     #[test]
     fn test_u32_bits() {
-        let mut bitter = BitGet::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee]);
         assert_eq!(bitter.read_u32_bits(10), Some(0x1ff));
         assert_eq!(bitter.read_u32_bits(10), Some(0x3b7));
         assert_eq!(bitter.read_u32_bits(10), Some(0x3fe));
@@ -918,7 +973,7 @@ mod tests {
 
     #[test]
     fn test_u32_unchecked() {
-        let mut bitter = BitGet::new(&[
+        let mut bitter = LittleEndianBits::new(&[
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         ]);
         assert_eq!(bitter.read_u32_unchecked(), 0xffff_ffff);
@@ -928,7 +983,7 @@ mod tests {
 
     #[test]
     fn test_u32_bits_unchecked() {
-        let mut bitter = BitGet::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee, 0xaa, 0xbb, 0xcc, 0xdd]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee, 0xaa, 0xbb, 0xcc, 0xdd]);
         assert_eq!(bitter.read_u32_bits_unchecked(10), 0x1ff);
         assert_eq!(bitter.read_u32_bits_unchecked(10), 0x3b7);
         assert_eq!(bitter.read_u32_bits_unchecked(10), 0x3fe);
@@ -943,7 +998,7 @@ mod tests {
 
     #[test]
     fn test_u32_bits_unchecked2() {
-        let mut bitter = BitGet::new(&[
+        let mut bitter = LittleEndianBits::new(&[
             0x9c, 0x73, 0xce, 0x39, 0xe7, 0x9c, 0x73, 0xce, 0x39, 0xe7, 0x9c, 0x73, 0xce, 0x39,
             0xe7,
         ]);
@@ -954,7 +1009,7 @@ mod tests {
 
     #[test]
     fn test_i32_bits_unchecked() {
-        let mut bitter = BitGet::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee, 0xaa, 0xbb, 0xcc, 0xdd]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee, 0xaa, 0xbb, 0xcc, 0xdd]);
         assert_eq!(bitter.read_i32_bits_unchecked(10), 0x1ff);
         assert_eq!(bitter.read_i32_bits_unchecked(10), 0x3b7);
         assert_eq!(bitter.read_i32_bits_unchecked(10), 0x3fe);
@@ -969,7 +1024,7 @@ mod tests {
 
     #[test]
     fn test_u32_bits2() {
-        let mut bitter = BitGet::new(&[
+        let mut bitter = LittleEndianBits::new(&[
             0x9c, 0x73, 0xce, 0x39, 0xe7, 0x9c, 0x73, 0xce, 0x39, 0xe7, 0x9c, 0x73, 0xce, 0x39,
             0xe7,
         ]);
@@ -980,7 +1035,7 @@ mod tests {
 
     #[test]
     fn test_i32_bits2() {
-        let mut bitter = BitGet::new(&[
+        let mut bitter = LittleEndianBits::new(&[
             0x9c, 0x73, 0xce, 0x39, 0xe7, 0x9c, 0x73, 0xce, 0x39, 0xe7, 0x9c, 0x73, 0xce, 0x39,
             0xe7,
         ]);
@@ -1003,55 +1058,55 @@ mod tests {
 
     #[test]
     fn test_max_read() {
-        let mut bitter = BitGet::new(&[0b1111_1000]);
+        let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
         assert_eq!(bitter.read_bits_max(20), Some(8));
         assert_eq!(bitter.read_bits_max(20), Some(15));
         assert_eq!(bitter.read_bits_max(20), None);
 
-        let mut bitter = BitGet::new(&[0b1111_0000]);
+        let mut bitter = LittleEndianBits::new(&[0b1111_0000]);
         assert_eq!(bitter.read_bits_max(20), Some(16));
         assert_eq!(bitter.read_bits_max(20), None);
 
-        let mut bitter = BitGet::new(&[0b1110_0010]);
+        let mut bitter = LittleEndianBits::new(&[0b1110_0010]);
         assert_eq!(bitter.read_bits_max(20), Some(2));
 
-        let mut bitter = BitGet::new(&[0b0001_0100]);
+        let mut bitter = LittleEndianBits::new(&[0b0001_0100]);
         assert_eq!(bitter.read_bits_max(20), Some(4));
 
-        let mut bitter = BitGet::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max(20), Some(19));
 
-        let mut bitter = BitGet::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max(0), Some(0));
 
-        let mut bitter = BitGet::new(&[0xff, 0xff, 0xff, 0xff]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0xff, 0xff, 0xff]);
         assert_eq!(bitter.read_bits_max(u32::max_value()), Some(0x7fff_ffff));
     }
 
     #[test]
     fn test_max_read_computed() {
-        let mut bitter = BitGet::new(&[0b1111_1000]);
+        let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
         assert_eq!(bitter.read_bits_max_computed(4, 20), Some(8));
         assert_eq!(bitter.read_bits_max_computed(4, 20), Some(15));
         assert_eq!(bitter.read_bits_max_computed(4, 20), None);
 
-        let mut bitter = BitGet::new(&[0b1111_0000]);
+        let mut bitter = LittleEndianBits::new(&[0b1111_0000]);
         assert_eq!(bitter.read_bits_max_computed(4, 20), Some(16));
         assert_eq!(bitter.read_bits_max_computed(4, 20), None);
 
-        let mut bitter = BitGet::new(&[0b1110_0010]);
+        let mut bitter = LittleEndianBits::new(&[0b1110_0010]);
         assert_eq!(bitter.read_bits_max_computed(4, 20), Some(2));
 
-        let mut bitter = BitGet::new(&[0b0001_0100]);
+        let mut bitter = LittleEndianBits::new(&[0b0001_0100]);
         assert_eq!(bitter.read_bits_max_computed(4, 20), Some(4));
 
-        let mut bitter = BitGet::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max_computed(4, 20), Some(19));
 
-        let mut bitter = BitGet::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max_computed(0, 00), Some(0));
 
-        let mut bitter = BitGet::new(&[0xff, 0xff, 0xff, 0xff]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0xff, 0xff, 0xff]);
         assert_eq!(
             bitter.read_bits_max_computed(31, u32::max_value()),
             Some(0x7fff_ffff)
@@ -1060,26 +1115,26 @@ mod tests {
 
     #[test]
     fn test_max_read_unchecked() {
-        let mut bitter = BitGet::new(&[0b1111_1000]);
+        let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
         assert_eq!(bitter.read_bits_max_unchecked(20), 8);
         assert_eq!(bitter.read_bits_max_unchecked(20), 15);
 
-        let mut bitter = BitGet::new(&[0b1111_0000]);
+        let mut bitter = LittleEndianBits::new(&[0b1111_0000]);
         assert_eq!(bitter.read_bits_max_unchecked(20), 16);
 
-        let mut bitter = BitGet::new(&[0b1110_0010]);
+        let mut bitter = LittleEndianBits::new(&[0b1110_0010]);
         assert_eq!(bitter.read_bits_max_unchecked(20), 2);
 
-        let mut bitter = BitGet::new(&[0b0001_0100]);
+        let mut bitter = LittleEndianBits::new(&[0b0001_0100]);
         assert_eq!(bitter.read_bits_max_unchecked(20), 4);
 
-        let mut bitter = BitGet::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max_unchecked(20), 19);
 
-        let mut bitter = BitGet::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max_unchecked(0), 0);
 
-        let mut bitter = BitGet::new(&[0xff, 0xff, 0xff, 0xff]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0xff, 0xff, 0xff]);
         assert_eq!(
             bitter.read_bits_max_unchecked(u32::max_value()),
             0x7fff_ffff
@@ -1088,26 +1143,26 @@ mod tests {
 
     #[test]
     fn test_max_read_unchecked_computed() {
-        let mut bitter = BitGet::new(&[0b1111_1000]);
+        let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
         assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 8);
         assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 15);
 
-        let mut bitter = BitGet::new(&[0b1111_0000]);
+        let mut bitter = LittleEndianBits::new(&[0b1111_0000]);
         assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 16);
 
-        let mut bitter = BitGet::new(&[0b1110_0010]);
+        let mut bitter = LittleEndianBits::new(&[0b1110_0010]);
         assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 2);
 
-        let mut bitter = BitGet::new(&[0b0001_0100]);
+        let mut bitter = LittleEndianBits::new(&[0b0001_0100]);
         assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 4);
 
-        let mut bitter = BitGet::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 19);
 
-        let mut bitter = BitGet::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max_computed_unchecked(0, 0), 0);
 
-        let mut bitter = BitGet::new(&[0xff, 0xff, 0xff, 0xff]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0xff, 0xff, 0xff]);
         assert_eq!(
             bitter.read_bits_max_computed_unchecked(31, u32::max_value()),
             0x7fff_ffff
@@ -1116,25 +1171,25 @@ mod tests {
 
     #[test]
     fn test_if_get() {
-        let mut bitter = BitGet::new(&[0xff, 0x04]);
-        assert_eq!(bitter.if_get(BitGet::read_u8), Some(Some(0x7f)));
-        assert_eq!(bitter.if_get(BitGet::read_u8), Some(None));
-        assert_eq!(bitter.if_get(BitGet::read_u8), None);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
+        assert_eq!(bitter.if_get(LittleEndianBits::read_u8), Some(Some(0x7f)));
+        assert_eq!(bitter.if_get(LittleEndianBits::read_u8), Some(None));
+        assert_eq!(bitter.if_get(LittleEndianBits::read_u8), None);
     }
 
     #[test]
     fn test_if_get_unchecked() {
-        let mut bitter = BitGet::new(&[0xff, 0x04]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
         assert_eq!(
-            bitter.if_get_unchecked(BitGet::read_u8_unchecked),
+            bitter.if_get_unchecked(LittleEndianBits::read_u8_unchecked),
             Some(0x7f)
         );
-        assert_eq!(bitter.if_get_unchecked(BitGet::read_u8_unchecked), None);
+        assert_eq!(bitter.if_get_unchecked(LittleEndianBits::read_u8_unchecked), None);
     }
 
     #[test]
     fn test_approx_bytes_and_empty() {
-        let mut bitter = BitGet::new(&[0xff, 0x04]);
+        let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
         assert!(!bitter.is_empty());
         assert_eq!(bitter.approx_bytes_remaining(), 2);
         assert!(bitter.read_bit().is_some());
@@ -1157,14 +1212,14 @@ mod tests {
     #[test]
     fn has_bits_remaining_max() {
         let data = vec![];
-        let bits = BitGet::new(data.as_slice());
+        let bits = LittleEndianBits::new(data.as_slice());
         assert_eq!(false, bits.has_bits_remaining(usize::max_value()));
     }
 
     #[test]
     fn i16_test() {
         let data = [0b1111_1111, 0b1111_1111];
-        let mut bits = BitGet::new(&data[..]);
+        let mut bits = LittleEndianBits::new(&data[..]);
 
         assert_eq!(bits.read_i16(), Some(i16::from_le_bytes(data)));
     }
@@ -1172,7 +1227,7 @@ mod tests {
     #[test]
     fn i16_min_test() {
         let data = [0b0000_0000, 0b1000_0000];
-        let mut bits = BitGet::new(&data[..]);
+        let mut bits = LittleEndianBits::new(&data[..]);
 
         assert_eq!(bits.read_i16(), Some(core::i16::MIN));
     }
@@ -1180,7 +1235,7 @@ mod tests {
     #[test]
     fn i16_max_test() {
         let data = [0b1111_1111, 0b0111_1111];
-        let mut bits = BitGet::new(&data[..]);
+        let mut bits = LittleEndianBits::new(&data[..]);
 
         assert_eq!(bits.read_i16(), Some(core::i16::MAX));
     }
@@ -1188,7 +1243,7 @@ mod tests {
     #[test]
     fn regression1() {
         let data = vec![0b0000_0010, 0b0011_1111, 0b1011_1100];
-        let mut bits = BitGet::new(data.as_slice());
+        let mut bits = LittleEndianBits::new(data.as_slice());
 
         assert_eq!(bits.read_u32_bits(3), Some(2));
         assert_eq!(bits.read_u8(), Some(224));
@@ -1199,7 +1254,7 @@ mod tests {
     #[test]
     fn regression2() {
         let data = vec![2, 63, 63, 2, 63, 2, 0, 0, 0];
-        let mut bits = BitGet::new(data.as_slice());
+        let mut bits = LittleEndianBits::new(data.as_slice());
 
         assert_eq!(bits.read_u32_bits(3), Some(2));
         assert_eq!(bits.read_u8(), Some(224));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -737,37 +737,12 @@ macro_rules! generate_bitter_end {
                 })
             }
 
-            /// Reads a value from the stream that consumes the same or fewer number of bits of a given
-            /// max. The value read will always be less than the given max.
-            ///
-            /// For example if one wants to read a value that is less than 20, bitter will read at least
-            /// 4 bits from the stream. If the 5th bit would cause the accumulator to exceed the max, the
-            /// 5th bit is not consumed. Else the 5th bit is consumed and added to accumulator.
-            ///
-            /// ```rust
-            /// # use bitter::{LittleEndianBits, BitOrder};
-            /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
-            /// assert_eq!(bitter.read_bits_max_unchecked(20), 8);
-            /// assert_eq!(bitter.read_bits_max_unchecked(20), 15);
-            /// ```
             #[inline]
             fn read_bits_max_unchecked(&mut self, max: u32) -> u32 {
                 let bits = bit_width(max) as i32 - 1;
                 self.read_bits_max_computed_unchecked(core::cmp::max(bits, 0), max)
             }
 
-            /// Same as `read_bits_max_unchecked` except that this function accepts the already computed
-            /// number of bits to at least read. For instance, if 20 is the max, then 4 bits are at least
-            /// needed.
-            ///
-            /// In general, prefer `read_bits_max_unchecked` for ease of use
-            ///
-            /// ```rust
-            /// # use bitter::{LittleEndianBits, BitOrder};
-            /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
-            /// assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 8);
-            /// assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 15);
-            /// ```
             #[inline]
             fn read_bits_max_computed_unchecked(&mut self, bits: i32, max: u32) -> u32 {
                 debug_assert!(core::cmp::max(bit_width(max) as i32, 1) == bits + 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ Bitter takes a slice of byte data and reads bits in a desired endian format plat
 ## Example
 
 ```rust
-use bitter::{BitOrder, LittleEndianBits};
+use bitter::{BitReader, LittleEndianBits};
 let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
 assert_eq!(bitter.read_bit(), Some(true));
 assert_eq!(bitter.read_u8(), Some(0x7f));
@@ -36,7 +36,7 @@ Tips:
 Below is a demonstration of the unchecked APIs with a guard to ensure safety:
 
 ```rust
-use bitter::{BitOrder, LittleEndianBits};
+use bitter::{BitReader, LittleEndianBits};
 let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
 if bitter.has_bits_remaining(16) {
     assert_eq!(bitter.read_bit_unchecked(), true);
@@ -48,7 +48,7 @@ if bitter.has_bits_remaining(16) {
 Another guard usage:
 
 ```rust
-use bitter::{BitOrder, LittleEndianBits};
+use bitter::{BitReader, LittleEndianBits};
 let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
 if bitter.has_bits_remaining(16) {
     for _ in 0..8 {
@@ -74,11 +74,11 @@ bitter = { version = "x", default-features = false }
 #![warn(missing_docs)]
 
 /// Read bits in a given endian order
-pub trait BitOrder {
+pub trait BitReader {
     /// Consume a bit and return if the bit was enabled
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let mut bits = BigEndianBits::new(&[0b1001_0011]);
     /// assert_eq!(bits.read_bit(), Some(true));
     /// assert_eq!(bits.read_bit(), Some(false));
@@ -88,7 +88,7 @@ pub trait BitOrder {
     /// Consume 8 bits and return the deserialized byte
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let mut bits = BigEndianBits::new(&[0b1001_0011]);
     /// assert_eq!(bits.read_u8(), Some(0b1001_0011));
     /// ```
@@ -97,7 +97,7 @@ pub trait BitOrder {
     /// Consume 8 bits and return the deserialized byte
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let mut bits = BigEndianBits::new(&[0b1001_0011]);
     /// assert_eq!(bits.read_i8(), Some(-109));
     /// ```
@@ -106,7 +106,7 @@ pub trait BitOrder {
     /// Consume 16 bits and return the deserialized short
     ///
     /// ```rust
-    /// use bitter::{BitOrder, LittleEndianBits};
+    /// use bitter::{BitReader, LittleEndianBits};
     /// let mut bits = LittleEndianBits::new(&[0b1001_0011, 0b1111_1111]);
     /// assert_eq!(bits.read_u16(), Some(0xff93));
     /// ```
@@ -115,7 +115,7 @@ pub trait BitOrder {
     /// Consume 16 bits and return the deserialized short
     ///
     /// ```rust
-    /// use bitter::{BitOrder, LittleEndianBits};
+    /// use bitter::{BitReader, LittleEndianBits};
     /// let data = (-500i16).to_le_bytes();
     /// let mut bits = LittleEndianBits::new(&data);
     /// assert_eq!(bits.read_i16(), Some(-500));
@@ -125,7 +125,7 @@ pub trait BitOrder {
     /// Consume 32 bits and return the deserialized int
     ///
     /// ```rust
-    /// use bitter::{BitOrder, LittleEndianBits};
+    /// use bitter::{BitReader, LittleEndianBits};
     /// let data = (22000u32).to_le_bytes();
     /// let mut bits = LittleEndianBits::new(&data);
     /// assert_eq!(bits.read_u32(), Some(22000u32));
@@ -135,7 +135,7 @@ pub trait BitOrder {
     /// Consume 32 bits and return the deserialized int
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let data = (-22000i32).to_be_bytes();
     /// let mut bits = BigEndianBits::new(&data);
     /// assert_eq!(bits.read_i32(), Some(-22000i32));
@@ -145,7 +145,7 @@ pub trait BitOrder {
     /// Consume 64 bits and return the deserialized long
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let data = (22000u64).to_be_bytes();
     /// let mut bits = BigEndianBits::new(&data);
     /// assert_eq!(bits.read_u64(), Some(22000u64));
@@ -155,7 +155,7 @@ pub trait BitOrder {
     /// Consume 64 bits and return the deserialized long
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let data = (-22000i64).to_be_bytes();
     /// let mut bits = BigEndianBits::new(&data);
     /// assert_eq!(bits.read_i64(), Some(-22000i64));
@@ -165,7 +165,7 @@ pub trait BitOrder {
     /// Consume 32 bits and return the deserialized floating point
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let data = 12.5f32.to_be_bytes();
     /// let mut bits = BigEndianBits::new(&data);
     /// assert_eq!(bits.read_f32(), Some(12.5f32));
@@ -176,7 +176,7 @@ pub trait BitOrder {
     /// and returns the unsigned result
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let mut bitter = BigEndianBits::new(&[0xff, 0x00, 0xab, 0xcd]);
     /// assert_eq!(bitter.read_u32_bits(32), Some(0xff00abcd));
     /// ```
@@ -186,7 +186,7 @@ pub trait BitOrder {
     /// and returns the signed result.
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let mut bitter = BigEndianBits::new(&[0xff, 0x00, 0xab, 0xcd]);
     /// let result = i32::from_be_bytes([0xff, 0x00, 0xab, 0xcd]);
     /// assert_eq!(bitter.read_i32_bits(32), Some(result));
@@ -201,11 +201,11 @@ pub trait BitOrder {
     /// - Some(x): Bit was on and data was decoded
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitOrder};
+    /// use bitter::{LittleEndianBits, BitReader};
     /// let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
-    /// assert_eq!(bitter.if_get(BitOrder::read_u8), Some(Some(0x7f)));
-    /// assert_eq!(bitter.if_get(BitOrder::read_u8), Some(None));
-    /// assert_eq!(bitter.if_get(BitOrder::read_u8), None);
+    /// assert_eq!(bitter.if_get(BitReader::read_u8), Some(Some(0x7f)));
+    /// assert_eq!(bitter.if_get(BitReader::read_u8), Some(None));
+    /// assert_eq!(bitter.if_get(BitReader::read_u8), None);
     /// ```
     fn if_get<T, F>(&mut self, f: F) -> Option<Option<T>>
     where
@@ -220,7 +220,7 @@ pub trait BitOrder {
     /// necessary number of bits are not available, `None` is returned.
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitOrder};
+    /// use bitter::{LittleEndianBits, BitReader};
     /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
     /// assert_eq!(bitter.read_bits_max(20), Some(8));
     /// assert_eq!(bitter.read_bits_max(20), Some(15));
@@ -234,7 +234,7 @@ pub trait BitOrder {
     /// computed max can lead to undefined behavior
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitOrder};
+    /// use bitter::{LittleEndianBits, BitReader};
     /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
     /// assert_eq!(bitter.read_bits_max_computed(4, 20), Some(8));
     /// assert_eq!(bitter.read_bits_max_computed(4, 20), Some(15));
@@ -244,7 +244,7 @@ pub trait BitOrder {
     /// *Assumes* there is at least one bit left in the stream.
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitOrder};
+    /// use bitter::{LittleEndianBits, BitReader};
     /// let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
     /// assert_eq!(bitter.read_bit_unchecked(), false);
     /// ```
@@ -253,7 +253,7 @@ pub trait BitOrder {
     /// *Assumes* there is at least 8 bits left in the stream.
     ///
     /// ```rust
-    /// use bitter::{BigEndianBits, BitOrder};
+    /// use bitter::{BigEndianBits, BitReader};
     /// let mut bitter = BigEndianBits::new(&[0b1010_1010, 0b0101_0101]);
     /// assert_eq!(bitter.read_u8_unchecked(), 0b1010_1010);
     /// ```
@@ -262,7 +262,7 @@ pub trait BitOrder {
     /// *Assumes* there is at least 8 bits left in the stream.
     ///
     /// ```rust
-    /// use bitter::{BigEndianBits, BitOrder};
+    /// use bitter::{BigEndianBits, BitReader};
     /// let mut bitter = BigEndianBits::new(&[0b1010_1010, 0b0101_0101]);
     /// assert_eq!(bitter.read_i8_unchecked(), i8::from_be_bytes([0b1010_1010]));
     /// ```
@@ -271,7 +271,7 @@ pub trait BitOrder {
     /// Consume 16 bits and return the deserialized short
     ///
     /// ```rust
-    /// use bitter::{BitOrder, LittleEndianBits};
+    /// use bitter::{BitReader, LittleEndianBits};
     /// let mut bits = LittleEndianBits::new(&[0b1001_0011, 0b1111_1111]);
     /// assert_eq!(bits.read_u16_unchecked(), 0xff93);
     /// ```
@@ -280,7 +280,7 @@ pub trait BitOrder {
     /// Consume 16 bits and return the deserialized short
     ///
     /// ```rust
-    /// use bitter::{BitOrder, LittleEndianBits};
+    /// use bitter::{BitReader, LittleEndianBits};
     /// let data = (-500i16).to_le_bytes();
     /// let mut bits = LittleEndianBits::new(&data);
     /// assert_eq!(bits.read_i16_unchecked(), -500);
@@ -290,7 +290,7 @@ pub trait BitOrder {
     /// Consume 32 bits and return the deserialized int
     ///
     /// ```rust
-    /// use bitter::{BitOrder, LittleEndianBits};
+    /// use bitter::{BitReader, LittleEndianBits};
     /// let data = (22000u32).to_le_bytes();
     /// let mut bits = LittleEndianBits::new(&data);
     /// assert_eq!(bits.read_u32_unchecked(), 22000u32);
@@ -300,7 +300,7 @@ pub trait BitOrder {
     /// Consume 32 bits and return the deserialized int
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let data = (-22000i32).to_be_bytes();
     /// let mut bits = BigEndianBits::new(&data);
     /// assert_eq!(bits.read_i32_unchecked(), -22000i32);
@@ -310,7 +310,7 @@ pub trait BitOrder {
     /// Consume 64 bits and return the deserialized long
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let data = (22000u64).to_be_bytes();
     /// let mut bits = BigEndianBits::new(&data);
     /// assert_eq!(bits.read_u64_unchecked(), 22000u64);
@@ -320,7 +320,7 @@ pub trait BitOrder {
     /// Consume 64 bits and return the deserialized long
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let data = (-22000i64).to_be_bytes();
     /// let mut bits = BigEndianBits::new(&data);
     /// assert_eq!(bits.read_i64_unchecked(), -22000i64);
@@ -330,7 +330,7 @@ pub trait BitOrder {
     /// Consume 32 bits and return the deserialized floating point
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let data = 12.5f32.to_be_bytes();
     /// let mut bits = BigEndianBits::new(&data);
     /// assert_eq!(bits.read_f32_unchecked(), 12.5f32);
@@ -341,9 +341,9 @@ pub trait BitOrder {
     /// and returns the unsigned result
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let mut bitter = BigEndianBits::new(&[0xff, 0x00, 0xab, 0xcd]);
-    /// assert_eq!(bitter.read_u32_bits(32), 0xff00abcd);
+    /// assert_eq!(bitter.read_u32_bits_unchecked(32), 0xff00abcd);
     /// ```
     fn read_u32_bits_unchecked(&mut self, bits: i32) -> u32;
 
@@ -351,10 +351,10 @@ pub trait BitOrder {
     /// and returns the signed result.
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let mut bitter = BigEndianBits::new(&[0xff, 0x00, 0xab, 0xcd]);
     /// let result = i32::from_be_bytes([0xff, 0x00, 0xab, 0xcd]);
-    /// assert_eq!(bitter.read_i32_bits(32), result);
+    /// assert_eq!(bitter.read_i32_bits_unchecked(32), result);
     /// ```
     fn read_i32_bits_unchecked(&mut self, bits: i32) -> i32;
 
@@ -365,7 +365,7 @@ pub trait BitOrder {
     /// - Some(x): Bit was on and data was decoded
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitOrder};
+    /// use bitter::{LittleEndianBits, BitReader};
     /// let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
     /// assert_eq!(bitter.if_get_unchecked(LittleEndianBits::read_u8_unchecked), Some(0x7f));
     /// assert_eq!(bitter.if_get_unchecked(LittleEndianBits::read_u8_unchecked), None);
@@ -383,7 +383,7 @@ pub trait BitOrder {
     /// necessary number of bits are not available, `None` is returned.
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitOrder};
+    /// use bitter::{LittleEndianBits, BitReader};
     /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
     /// assert_eq!(bitter.read_bits_max_unchecked(20), 8);
     /// assert_eq!(bitter.read_bits_max_unchecked(20), 15);
@@ -397,7 +397,7 @@ pub trait BitOrder {
     /// computed max can lead to undefined behavior
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitOrder};
+    /// use bitter::{LittleEndianBits, BitReader};
     /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
     /// assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 8);
     /// assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 15);
@@ -410,7 +410,7 @@ pub trait BitOrder {
     /// than sign to avoid undefined behavior with unchecked reads
     ///
     /// ```rust
-    /// # use bitter::{LittleEndianBits, BitOrder};
+    /// # use bitter::{LittleEndianBits, BitReader};
     /// let mut bitter = LittleEndianBits::new(&[0xff]);
     /// assert_eq!(bitter.approx_bytes_remaining(), 1);
     /// assert!(bitter.read_bit().is_some());
@@ -426,7 +426,7 @@ pub trait BitOrder {
     /// ergonomic alternative.
     ///
     /// ```rust
-    /// # use bitter::{LittleEndianBits, BitOrder};
+    /// # use bitter::{LittleEndianBits, BitReader};
     /// let mut bitter = LittleEndianBits::new(&[0xff]);
     /// assert_eq!(bitter.bits_remaining(), Some(8));
     /// assert!(bitter.read_bit().is_some());
@@ -440,7 +440,7 @@ pub trait BitOrder {
     /// and ergonomic way than `bits_remaining`.
     ///
     /// ```rust
-    /// # use bitter::{LittleEndianBits, BitOrder};
+    /// # use bitter::{LittleEndianBits, BitReader};
     /// let mut bitter = LittleEndianBits::new(&[0xff]);
     /// assert!(bitter.has_bits_remaining(7));
     /// assert!(bitter.has_bits_remaining(8));
@@ -460,7 +460,7 @@ pub trait BitOrder {
     /// the read was successful and the buffer has been filled.
     ///
     /// ```rust
-    /// # use bitter::{LittleEndianBits, BitOrder};
+    /// # use bitter::{LittleEndianBits, BitReader};
     /// let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
     /// let mut buf = [0; 1];
     /// assert_eq!(bitter.read_bit_unchecked(), false);
@@ -473,7 +473,7 @@ pub trait BitOrder {
     /// Returns if the bitstream has no bits left
     ///
     /// ```rust
-    /// # use bitter::{LittleEndianBits, BitOrder};
+    /// # use bitter::{LittleEndianBits, BitReader};
     /// let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
     /// assert_eq!(bitter.is_empty(), false);
     /// assert_eq!(bitter.read_u16_unchecked(), 0b0101_0101_1010_1010);
@@ -560,7 +560,7 @@ macro_rules! generate_bitter_end {
             }
         }
 
-        impl<'a> BitOrder for $name<'a> {
+        impl<'a> BitReader for $name<'a> {
             gen_read!(read_u8, u8);
             gen_read!(read_i8, i8);
             gen_read!(read_u16, u16);
@@ -767,7 +767,7 @@ generate_bitter_end!(
     /// Reads bits in the little-endian format
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let mut lebits = BigEndianBits::new(&[0b1000_0000]);
     /// assert_eq!(lebits.read_bit(), Some(true));
     /// ```
@@ -777,7 +777,7 @@ generate_bitter_end!(
     /// Reads bits in the big-endian format
     ///
     /// ```rust
-    /// use bitter::{BitOrder, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianBits};
     /// let mut bebits = BigEndianBits::new(&[0b1000_0000]);
     /// assert_eq!(bebits.read_bit(), Some(true));
     /// ```
@@ -1034,7 +1034,7 @@ impl<'a> BigEndianBits<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{bit_width, BitOrder, LittleEndianBits};
+    use super::{bit_width, BitReader, LittleEndianBits};
 
     #[test]
     fn test_bit_reads() {
@@ -1659,7 +1659,7 @@ mod tests {
 
 #[cfg(test)]
 mod be_tests {
-    use super::{BigEndianBits, BitOrder};
+    use super::{BigEndianBits, BitReader};
 
     #[test]
     fn test_be_bit_bits_reads() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@ Bitter takes a slice of byte data and reads bits in a desired endian format plat
  - ✔ > 5 GB/s throughput when reading large number of bits
  - ✔ > 1 GB/s throughput when reading single digit sized chunks of bits
  - ✔ two APIs: one for safety and one for speed
- - ✔ zero allocations
+ - ✔ zero dependencies
+ - ✔ zer  o allocations
  - ✔ `no_std` compatible
 
 ## Example
@@ -805,15 +806,15 @@ impl<'a> LittleEndianBits<'a> {
             if self.data.len() >= BYTE_WIDTH {
                 core::ptr::read_unaligned(self.data.as_ptr() as *const u8 as *const u64).to_le()
             } else {
-                let mut data: u64 = 0;
+                let mut result: u64 = 0;
                 let len = self.data.len();
                 core::ptr::copy_nonoverlapping(
                     self.data.as_ptr(),
-                    &mut data as *mut u64 as *mut u8,
+                    &mut result as *mut u64 as *mut u8,
                     len,
                 );
                 self.last_read = true;
-                data.to_le()
+                result.to_le()
             }
         }
     }
@@ -924,15 +925,15 @@ impl<'a> BigEndianBits<'a> {
             if self.data.len() >= BYTE_WIDTH {
                 core::ptr::read_unaligned(self.data.as_ptr() as *const u8 as *const u64).to_be()
             } else {
-                let mut data: u64 = 0;
+                let mut result: u64 = 0;
                 let len = self.data.len();
                 core::ptr::copy_nonoverlapping(
                     self.data.as_ptr(),
-                    &mut data as *mut u64 as *mut u8,
+                    &mut result as *mut u64 as *mut u8,
                     len,
                 );
                 self.last_read = true;
-                data.to_be()
+                result.to_be()
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@ Bitter takes a slice of byte data and reads bits in a desired endian format plat
 ## Example
 
 ```rust
-use bitter::{BitReader, LittleEndianBits};
-let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
+use bitter::{BitReader, LittleEndianReader};
+let mut bitter = LittleEndianReader::new(&[0xff, 0x04]);
 assert_eq!(bitter.read_bit(), Some(true));
 assert_eq!(bitter.read_u8(), Some(0x7f));
 assert_eq!(bitter.read_u32_bits(7), Some(0x02));
@@ -37,8 +37,8 @@ Tips:
 Below is a demonstration of the unchecked APIs with a guard to ensure safety:
 
 ```rust
-use bitter::{BitReader, LittleEndianBits};
-let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
+use bitter::{BitReader, LittleEndianReader};
+let mut bitter = LittleEndianReader::new(&[0xff, 0x04]);
 if bitter.has_bits_remaining(16) {
     assert_eq!(bitter.read_bit_unchecked(), true);
     assert_eq!(bitter.read_u8_unchecked(), 0x7f);
@@ -49,8 +49,8 @@ if bitter.has_bits_remaining(16) {
 Another guard usage:
 
 ```rust
-use bitter::{BitReader, LittleEndianBits};
-let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
+use bitter::{BitReader, LittleEndianReader};
+let mut bitter = LittleEndianReader::new(&[0xff, 0x04]);
 if bitter.has_bits_remaining(16) {
     for _ in 0..8 {
         assert_eq!(bitter.read_bit_unchecked(), true);
@@ -79,8 +79,8 @@ pub trait BitReader {
     /// Consume a bit and return if the bit was enabled
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
-    /// let mut bits = BigEndianBits::new(&[0b1001_0011]);
+    /// use bitter::{BitReader, BigEndianReader};
+    /// let mut bits = BigEndianReader::new(&[0b1001_0011]);
     /// assert_eq!(bits.read_bit(), Some(true));
     /// assert_eq!(bits.read_bit(), Some(false));
     /// ```
@@ -89,8 +89,8 @@ pub trait BitReader {
     /// Consume 8 bits and return the deserialized byte
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
-    /// let mut bits = BigEndianBits::new(&[0b1001_0011]);
+    /// use bitter::{BitReader, BigEndianReader};
+    /// let mut bits = BigEndianReader::new(&[0b1001_0011]);
     /// assert_eq!(bits.read_u8(), Some(0b1001_0011));
     /// ```
     fn read_u8(&mut self) -> Option<u8>;
@@ -98,8 +98,8 @@ pub trait BitReader {
     /// Consume 8 bits and return the deserialized byte
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
-    /// let mut bits = BigEndianBits::new(&[0b1001_0011]);
+    /// use bitter::{BitReader, BigEndianReader};
+    /// let mut bits = BigEndianReader::new(&[0b1001_0011]);
     /// assert_eq!(bits.read_i8(), Some(-109));
     /// ```
     fn read_i8(&mut self) -> Option<i8>;
@@ -107,8 +107,8 @@ pub trait BitReader {
     /// Consume 16 bits and return the deserialized short
     ///
     /// ```rust
-    /// use bitter::{BitReader, LittleEndianBits};
-    /// let mut bits = LittleEndianBits::new(&[0b1001_0011, 0b1111_1111]);
+    /// use bitter::{BitReader, LittleEndianReader};
+    /// let mut bits = LittleEndianReader::new(&[0b1001_0011, 0b1111_1111]);
     /// assert_eq!(bits.read_u16(), Some(0xff93));
     /// ```
     fn read_u16(&mut self) -> Option<u16>;
@@ -116,9 +116,9 @@ pub trait BitReader {
     /// Consume 16 bits and return the deserialized short
     ///
     /// ```rust
-    /// use bitter::{BitReader, LittleEndianBits};
+    /// use bitter::{BitReader, LittleEndianReader};
     /// let data = (-500i16).to_le_bytes();
-    /// let mut bits = LittleEndianBits::new(&data);
+    /// let mut bits = LittleEndianReader::new(&data);
     /// assert_eq!(bits.read_i16(), Some(-500));
     /// ```
     fn read_i16(&mut self) -> Option<i16>;
@@ -126,9 +126,9 @@ pub trait BitReader {
     /// Consume 32 bits and return the deserialized int
     ///
     /// ```rust
-    /// use bitter::{BitReader, LittleEndianBits};
+    /// use bitter::{BitReader, LittleEndianReader};
     /// let data = (22000u32).to_le_bytes();
-    /// let mut bits = LittleEndianBits::new(&data);
+    /// let mut bits = LittleEndianReader::new(&data);
     /// assert_eq!(bits.read_u32(), Some(22000u32));
     /// ```
     fn read_u32(&mut self) -> Option<u32>;
@@ -136,9 +136,9 @@ pub trait BitReader {
     /// Consume 32 bits and return the deserialized int
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianReader};
     /// let data = (-22000i32).to_be_bytes();
-    /// let mut bits = BigEndianBits::new(&data);
+    /// let mut bits = BigEndianReader::new(&data);
     /// assert_eq!(bits.read_i32(), Some(-22000i32));
     /// ```
     fn read_i32(&mut self) -> Option<i32>;
@@ -146,9 +146,9 @@ pub trait BitReader {
     /// Consume 64 bits and return the deserialized long
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianReader};
     /// let data = (22000u64).to_be_bytes();
-    /// let mut bits = BigEndianBits::new(&data);
+    /// let mut bits = BigEndianReader::new(&data);
     /// assert_eq!(bits.read_u64(), Some(22000u64));
     /// ```
     fn read_u64(&mut self) -> Option<u64>;
@@ -156,9 +156,9 @@ pub trait BitReader {
     /// Consume 64 bits and return the deserialized long
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianReader};
     /// let data = (-22000i64).to_be_bytes();
-    /// let mut bits = BigEndianBits::new(&data);
+    /// let mut bits = BigEndianReader::new(&data);
     /// assert_eq!(bits.read_i64(), Some(-22000i64));
     /// ```
     fn read_i64(&mut self) -> Option<i64>;
@@ -166,9 +166,9 @@ pub trait BitReader {
     /// Consume 32 bits and return the deserialized floating point
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianReader};
     /// let data = 12.5f32.to_be_bytes();
-    /// let mut bits = BigEndianBits::new(&data);
+    /// let mut bits = BigEndianReader::new(&data);
     /// assert_eq!(bits.read_f32(), Some(12.5f32));
     /// ```
     fn read_f32(&mut self) -> Option<f32>;
@@ -177,8 +177,8 @@ pub trait BitReader {
     /// and returns the unsigned result
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
-    /// let mut bitter = BigEndianBits::new(&[0xff, 0x00, 0xab, 0xcd]);
+    /// use bitter::{BitReader, BigEndianReader};
+    /// let mut bitter = BigEndianReader::new(&[0xff, 0x00, 0xab, 0xcd]);
     /// assert_eq!(bitter.read_u32_bits(32), Some(0xff00abcd));
     /// ```
     fn read_u32_bits(&mut self, bits: i32) -> Option<u32>;
@@ -187,8 +187,8 @@ pub trait BitReader {
     /// and returns the signed result.
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
-    /// let mut bitter = BigEndianBits::new(&[0xff, 0x00, 0xab, 0xcd]);
+    /// use bitter::{BitReader, BigEndianReader};
+    /// let mut bitter = BigEndianReader::new(&[0xff, 0x00, 0xab, 0xcd]);
     /// let result = i32::from_be_bytes([0xff, 0x00, 0xab, 0xcd]);
     /// assert_eq!(bitter.read_i32_bits(32), Some(result));
     /// ```
@@ -202,8 +202,8 @@ pub trait BitReader {
     /// - Some(x): Bit was on and data was decoded
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitReader};
-    /// let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
+    /// use bitter::{LittleEndianReader, BitReader};
+    /// let mut bitter = LittleEndianReader::new(&[0xff, 0x04]);
     /// assert_eq!(bitter.if_get(BitReader::read_u8), Some(Some(0x7f)));
     /// assert_eq!(bitter.if_get(BitReader::read_u8), Some(None));
     /// assert_eq!(bitter.if_get(BitReader::read_u8), None);
@@ -221,8 +221,8 @@ pub trait BitReader {
     /// necessary number of bits are not available, `None` is returned.
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitReader};
-    /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
+    /// use bitter::{LittleEndianReader, BitReader};
+    /// let mut bitter = LittleEndianReader::new(&[0b1111_1000]);
     /// assert_eq!(bitter.read_bits_max(20), Some(8));
     /// assert_eq!(bitter.read_bits_max(20), Some(15));
     /// ```
@@ -235,8 +235,8 @@ pub trait BitReader {
     /// computed max can lead to undefined behavior
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitReader};
-    /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
+    /// use bitter::{LittleEndianReader, BitReader};
+    /// let mut bitter = LittleEndianReader::new(&[0b1111_1000]);
     /// assert_eq!(bitter.read_bits_max_computed(4, 20), Some(8));
     /// assert_eq!(bitter.read_bits_max_computed(4, 20), Some(15));
     /// ```
@@ -245,8 +245,8 @@ pub trait BitReader {
     /// *Assumes* there is at least one bit left in the stream.
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitReader};
-    /// let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+    /// use bitter::{LittleEndianReader, BitReader};
+    /// let mut bitter = LittleEndianReader::new(&[0b1010_1010, 0b0101_0101]);
     /// assert_eq!(bitter.read_bit_unchecked(), false);
     /// ```
     fn read_bit_unchecked(&mut self) -> bool;
@@ -254,8 +254,8 @@ pub trait BitReader {
     /// *Assumes* there is at least 8 bits left in the stream.
     ///
     /// ```rust
-    /// use bitter::{BigEndianBits, BitReader};
-    /// let mut bitter = BigEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+    /// use bitter::{BigEndianReader, BitReader};
+    /// let mut bitter = BigEndianReader::new(&[0b1010_1010, 0b0101_0101]);
     /// assert_eq!(bitter.read_u8_unchecked(), 0b1010_1010);
     /// ```
     fn read_u8_unchecked(&mut self) -> u8;
@@ -263,8 +263,8 @@ pub trait BitReader {
     /// *Assumes* there is at least 8 bits left in the stream.
     ///
     /// ```rust
-    /// use bitter::{BigEndianBits, BitReader};
-    /// let mut bitter = BigEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+    /// use bitter::{BigEndianReader, BitReader};
+    /// let mut bitter = BigEndianReader::new(&[0b1010_1010, 0b0101_0101]);
     /// assert_eq!(bitter.read_i8_unchecked(), i8::from_be_bytes([0b1010_1010]));
     /// ```
     fn read_i8_unchecked(&mut self) -> i8;
@@ -272,8 +272,8 @@ pub trait BitReader {
     /// Consume 16 bits and return the deserialized short
     ///
     /// ```rust
-    /// use bitter::{BitReader, LittleEndianBits};
-    /// let mut bits = LittleEndianBits::new(&[0b1001_0011, 0b1111_1111]);
+    /// use bitter::{BitReader, LittleEndianReader};
+    /// let mut bits = LittleEndianReader::new(&[0b1001_0011, 0b1111_1111]);
     /// assert_eq!(bits.read_u16_unchecked(), 0xff93);
     /// ```
     fn read_u16_unchecked(&mut self) -> u16;
@@ -281,9 +281,9 @@ pub trait BitReader {
     /// Consume 16 bits and return the deserialized short
     ///
     /// ```rust
-    /// use bitter::{BitReader, LittleEndianBits};
+    /// use bitter::{BitReader, LittleEndianReader};
     /// let data = (-500i16).to_le_bytes();
-    /// let mut bits = LittleEndianBits::new(&data);
+    /// let mut bits = LittleEndianReader::new(&data);
     /// assert_eq!(bits.read_i16_unchecked(), -500);
     /// ```
     fn read_i16_unchecked(&mut self) -> i16;
@@ -291,9 +291,9 @@ pub trait BitReader {
     /// Consume 32 bits and return the deserialized int
     ///
     /// ```rust
-    /// use bitter::{BitReader, LittleEndianBits};
+    /// use bitter::{BitReader, LittleEndianReader};
     /// let data = (22000u32).to_le_bytes();
-    /// let mut bits = LittleEndianBits::new(&data);
+    /// let mut bits = LittleEndianReader::new(&data);
     /// assert_eq!(bits.read_u32_unchecked(), 22000u32);
     /// ```
     fn read_u32_unchecked(&mut self) -> u32;
@@ -301,9 +301,9 @@ pub trait BitReader {
     /// Consume 32 bits and return the deserialized int
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianReader};
     /// let data = (-22000i32).to_be_bytes();
-    /// let mut bits = BigEndianBits::new(&data);
+    /// let mut bits = BigEndianReader::new(&data);
     /// assert_eq!(bits.read_i32_unchecked(), -22000i32);
     /// ```
     fn read_i32_unchecked(&mut self) -> i32;
@@ -311,9 +311,9 @@ pub trait BitReader {
     /// Consume 64 bits and return the deserialized long
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianReader};
     /// let data = (22000u64).to_be_bytes();
-    /// let mut bits = BigEndianBits::new(&data);
+    /// let mut bits = BigEndianReader::new(&data);
     /// assert_eq!(bits.read_u64_unchecked(), 22000u64);
     /// ```
     fn read_u64_unchecked(&mut self) -> u64;
@@ -321,9 +321,9 @@ pub trait BitReader {
     /// Consume 64 bits and return the deserialized long
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianReader};
     /// let data = (-22000i64).to_be_bytes();
-    /// let mut bits = BigEndianBits::new(&data);
+    /// let mut bits = BigEndianReader::new(&data);
     /// assert_eq!(bits.read_i64_unchecked(), -22000i64);
     /// ```
     fn read_i64_unchecked(&mut self) -> i64;
@@ -331,9 +331,9 @@ pub trait BitReader {
     /// Consume 32 bits and return the deserialized floating point
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
+    /// use bitter::{BitReader, BigEndianReader};
     /// let data = 12.5f32.to_be_bytes();
-    /// let mut bits = BigEndianBits::new(&data);
+    /// let mut bits = BigEndianReader::new(&data);
     /// assert_eq!(bits.read_f32_unchecked(), 12.5f32);
     /// ```
     fn read_f32_unchecked(&mut self) -> f32;
@@ -342,8 +342,8 @@ pub trait BitReader {
     /// and returns the unsigned result
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
-    /// let mut bitter = BigEndianBits::new(&[0xff, 0x00, 0xab, 0xcd]);
+    /// use bitter::{BitReader, BigEndianReader};
+    /// let mut bitter = BigEndianReader::new(&[0xff, 0x00, 0xab, 0xcd]);
     /// assert_eq!(bitter.read_u32_bits_unchecked(32), 0xff00abcd);
     /// ```
     fn read_u32_bits_unchecked(&mut self, bits: i32) -> u32;
@@ -352,8 +352,8 @@ pub trait BitReader {
     /// and returns the signed result.
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
-    /// let mut bitter = BigEndianBits::new(&[0xff, 0x00, 0xab, 0xcd]);
+    /// use bitter::{BitReader, BigEndianReader};
+    /// let mut bitter = BigEndianReader::new(&[0xff, 0x00, 0xab, 0xcd]);
     /// let result = i32::from_be_bytes([0xff, 0x00, 0xab, 0xcd]);
     /// assert_eq!(bitter.read_i32_bits_unchecked(32), result);
     /// ```
@@ -366,10 +366,10 @@ pub trait BitReader {
     /// - Some(x): Bit was on and data was decoded
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitReader};
-    /// let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
-    /// assert_eq!(bitter.if_get_unchecked(LittleEndianBits::read_u8_unchecked), Some(0x7f));
-    /// assert_eq!(bitter.if_get_unchecked(LittleEndianBits::read_u8_unchecked), None);
+    /// use bitter::{LittleEndianReader, BitReader};
+    /// let mut bitter = LittleEndianReader::new(&[0xff, 0x04]);
+    /// assert_eq!(bitter.if_get_unchecked(LittleEndianReader::read_u8_unchecked), Some(0x7f));
+    /// assert_eq!(bitter.if_get_unchecked(LittleEndianReader::read_u8_unchecked), None);
     /// ```
     fn if_get_unchecked<T, F>(&mut self, f: F) -> Option<T>
     where
@@ -384,8 +384,8 @@ pub trait BitReader {
     /// necessary number of bits are not available, `None` is returned.
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitReader};
-    /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
+    /// use bitter::{LittleEndianReader, BitReader};
+    /// let mut bitter = LittleEndianReader::new(&[0b1111_1000]);
     /// assert_eq!(bitter.read_bits_max_unchecked(20), 8);
     /// assert_eq!(bitter.read_bits_max_unchecked(20), 15);
     /// ```
@@ -398,8 +398,8 @@ pub trait BitReader {
     /// computed max can lead to undefined behavior
     ///
     /// ```rust
-    /// use bitter::{LittleEndianBits, BitReader};
-    /// let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
+    /// use bitter::{LittleEndianReader, BitReader};
+    /// let mut bitter = LittleEndianReader::new(&[0b1111_1000]);
     /// assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 8);
     /// assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 15);
     /// ```
@@ -411,8 +411,8 @@ pub trait BitReader {
     /// than sign to avoid undefined behavior with unchecked reads
     ///
     /// ```rust
-    /// # use bitter::{LittleEndianBits, BitReader};
-    /// let mut bitter = LittleEndianBits::new(&[0xff]);
+    /// # use bitter::{LittleEndianReader, BitReader};
+    /// let mut bitter = LittleEndianReader::new(&[0xff]);
     /// assert_eq!(bitter.approx_bytes_remaining(), 1);
     /// assert!(bitter.read_bit().is_some());
     /// assert_eq!(bitter.approx_bytes_remaining(), 1);
@@ -427,8 +427,8 @@ pub trait BitReader {
     /// ergonomic alternative.
     ///
     /// ```rust
-    /// # use bitter::{LittleEndianBits, BitReader};
-    /// let mut bitter = LittleEndianBits::new(&[0xff]);
+    /// # use bitter::{LittleEndianReader, BitReader};
+    /// let mut bitter = LittleEndianReader::new(&[0xff]);
     /// assert_eq!(bitter.bits_remaining(), Some(8));
     /// assert!(bitter.read_bit().is_some());
     /// assert_eq!(bitter.bits_remaining(), Some(7));
@@ -441,8 +441,8 @@ pub trait BitReader {
     /// and ergonomic way than `bits_remaining`.
     ///
     /// ```rust
-    /// # use bitter::{LittleEndianBits, BitReader};
-    /// let mut bitter = LittleEndianBits::new(&[0xff]);
+    /// # use bitter::{LittleEndianReader, BitReader};
+    /// let mut bitter = LittleEndianReader::new(&[0xff]);
     /// assert!(bitter.has_bits_remaining(7));
     /// assert!(bitter.has_bits_remaining(8));
     /// assert!(!bitter.has_bits_remaining(9));
@@ -461,8 +461,8 @@ pub trait BitReader {
     /// the read was successful and the buffer has been filled.
     ///
     /// ```rust
-    /// # use bitter::{LittleEndianBits, BitReader};
-    /// let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+    /// # use bitter::{LittleEndianReader, BitReader};
+    /// let mut bitter = LittleEndianReader::new(&[0b1010_1010, 0b0101_0101]);
     /// let mut buf = [0; 1];
     /// assert_eq!(bitter.read_bit_unchecked(), false);
     /// assert!(bitter.read_bytes(&mut buf));
@@ -474,8 +474,8 @@ pub trait BitReader {
     /// Returns if the bitstream has no bits left
     ///
     /// ```rust
-    /// # use bitter::{LittleEndianBits, BitReader};
-    /// let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+    /// # use bitter::{LittleEndianReader, BitReader};
+    /// let mut bitter = LittleEndianReader::new(&[0b1010_1010, 0b0101_0101]);
     /// assert_eq!(bitter.is_empty(), false);
     /// assert_eq!(bitter.read_u16_unchecked(), 0b0101_0101_1010_1010);
     /// assert_eq!(bitter.is_empty(), true);
@@ -782,32 +782,32 @@ generate_bitter_end!(
     /// Reads bits in the little-endian format
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
-    /// let mut lebits = BigEndianBits::new(&[0b1000_0000]);
+    /// use bitter::{BitReader, BigEndianReader};
+    /// let mut lebits = BigEndianReader::new(&[0b1000_0000]);
     /// assert_eq!(lebits.read_bit(), Some(true));
     /// ```
-    LittleEndianBits
+    LittleEndianReader
 );
 generate_bitter_end!(
     /// Reads bits in the big-endian format
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianBits};
-    /// let mut bebits = BigEndianBits::new(&[0b1000_0000]);
+    /// use bitter::{BitReader, BigEndianReader};
+    /// let mut bebits = BigEndianReader::new(&[0b1000_0000]);
     /// assert_eq!(bebits.read_bit(), Some(true));
     /// ```
-    BigEndianBits
+    BigEndianReader
 );
 
 /// Read bits in system native-endian format
 #[cfg(target_endian = "little")]
-pub type NativeEndianBits<'a> = LittleEndianBits<'a>;
+pub type NativeEndianReader<'a> = LittleEndianReader<'a>;
 
 /// Read bits in system native-endian format
 #[cfg(target_endian = "big")]
-pub type NativeEndianBits<'a> = BigEndianBits<'a>;
+pub type NativeEndianReader<'a> = BigEndianReader<'a>;
 
-impl<'a> LittleEndianBits<'a> {
+impl<'a> LittleEndianReader<'a> {
     /// Assuming that `self.data` is pointing to data not yet seen. slurp up 8 bytes or the
     /// rest of the data (whatever is smaller)
     ///
@@ -917,7 +917,7 @@ impl<'a> LittleEndianBits<'a> {
     }
 }
 
-impl<'a> BigEndianBits<'a> {
+impl<'a> BigEndianReader<'a> {
     /// Assuming that `self.data` is pointing to data not yet seen. slurp up 8 bytes or the
     /// rest of the data (whatever is smaller)
     ///
@@ -1031,11 +1031,11 @@ impl<'a> BigEndianBits<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{bit_width, BitReader, LittleEndianBits};
+    use super::{bit_width, BitReader, LittleEndianReader};
 
     #[test]
     fn test_bit_reads() {
-        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianReader::new(&[0b1010_1010, 0b0101_0101]);
         assert_eq!(bitter.bits_remaining(), Some(16));
         assert_eq!(bitter.read_bit().unwrap(), false);
         assert_eq!(bitter.bits_remaining(), Some(15));
@@ -1061,7 +1061,7 @@ mod tests {
 
     #[test]
     fn test_bit_unchecked_reads() {
-        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianReader::new(&[0b1010_1010, 0b0101_0101]);
         assert_eq!(bitter.read_bit_unchecked(), false);
         assert_eq!(bitter.read_bit_unchecked(), true);
         assert_eq!(bitter.read_bit_unchecked(), false);
@@ -1085,7 +1085,7 @@ mod tests {
 
     #[test]
     fn test_bit_unchecked_bits_reads() {
-        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianReader::new(&[0b1010_1010, 0b0101_0101]);
         assert_eq!(bitter.read_u32_bits_unchecked(1), 0);
         assert_eq!(bitter.read_u32_bits_unchecked(1), 1);
         assert_eq!(bitter.read_u32_bits_unchecked(1), 0);
@@ -1109,7 +1109,7 @@ mod tests {
 
     #[test]
     fn test_has_remaining_bits() {
-        let mut bitter = LittleEndianBits::new(&[0xff, 0xff]);
+        let mut bitter = LittleEndianReader::new(&[0xff, 0xff]);
         assert!(bitter.has_bits_remaining(7));
         assert!(bitter.has_bits_remaining(8));
         assert!(bitter.has_bits_remaining(9));
@@ -1126,7 +1126,7 @@ mod tests {
 
     #[test]
     fn test_has_remaining_bits2() {
-        let mut bitter = LittleEndianBits::new(&[0xff, 0xff, 0xff, 0xff]);
+        let mut bitter = LittleEndianReader::new(&[0xff, 0xff, 0xff, 0xff]);
         assert!(bitter.read_u32_bits(31).is_some());
         assert!(!bitter.has_bits_remaining(2));
         assert!(bitter.has_bits_remaining(1));
@@ -1134,7 +1134,7 @@ mod tests {
 
     #[test]
     fn test_has_remaining_bits_bit_by_bit() {
-        let mut bitter = LittleEndianBits::new(&[0, 0, 0, 0, 0, 0, 0, 0]);
+        let mut bitter = LittleEndianReader::new(&[0, 0, 0, 0, 0, 0, 0, 0]);
         for _ in 0..200 {
             assert!(bitter.has_bits_remaining(1), bitter.read_bit().is_some());
         }
@@ -1142,13 +1142,13 @@ mod tests {
 
     #[test]
     fn test_16_bits_reads() {
-        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianReader::new(&[0b1010_1010, 0b0101_0101]);
         assert_eq!(bitter.read_u32_bits(16), Some(0b0101_0101_1010_1010));
     }
 
     #[test]
     fn test_bit_bits_reads() {
-        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianReader::new(&[0b1010_1010, 0b0101_0101]);
         assert_eq!(bitter.read_u32_bits(1), Some(0));
         assert_eq!(bitter.read_u32_bits(1), Some(1));
         assert_eq!(bitter.read_u32_bits(1), Some(0));
@@ -1172,11 +1172,11 @@ mod tests {
     #[test]
     fn test_read_bytes() {
         let mut buf = [0u8; 2];
-        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianReader::new(&[0b1010_1010, 0b0101_0101]);
         assert!(bitter.read_bytes(&mut buf));
         assert_eq!(&buf, &[0b1010_1010, 0b0101_0101]);
 
-        let mut bitter = LittleEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = LittleEndianReader::new(&[0b1010_1010, 0b0101_0101]);
         assert_eq!(bitter.read_bit_unchecked(), false);
         assert!(!bitter.read_bytes(&mut buf));
         assert!(bitter.read_bytes(&mut buf[0..1]));
@@ -1185,13 +1185,13 @@ mod tests {
 
     #[test]
     fn test_read_bytes2() {
-        let mut bitter = LittleEndianBits::new(&[]);
+        let mut bitter = LittleEndianReader::new(&[]);
         assert!(bitter.read_bytes(&mut []));
     }
 
     #[test]
     fn test_read_bytes3() {
-        let mut bitter = LittleEndianBits::new(&[0, 0]);
+        let mut bitter = LittleEndianReader::new(&[0, 0]);
         let mut buf = [0u8; 1];
         assert!(bitter.read_bytes(&mut buf));
         assert_eq!(&buf, &[0]);
@@ -1199,7 +1199,7 @@ mod tests {
 
     #[test]
     fn test_read_bytes4() {
-        let mut bitter = LittleEndianBits::new(&[0, 120]);
+        let mut bitter = LittleEndianReader::new(&[0, 120]);
         let mut buf = [0u8; 1];
         assert!(bitter.read_bytes(&mut buf));
         assert_eq!(&buf, &[0]);
@@ -1208,7 +1208,7 @@ mod tests {
 
     #[test]
     fn test_read_bytes5() {
-        let mut bitter = LittleEndianBits::new(&[119, 0, 120]);
+        let mut bitter = LittleEndianReader::new(&[119, 0, 120]);
         assert_eq!(bitter.read_u32_bits_unchecked(8), 119);
         let mut buf = [0u8; 1];
         assert!(bitter.read_bytes(&mut buf));
@@ -1218,7 +1218,7 @@ mod tests {
 
     #[test]
     fn test_u8_reads() {
-        let mut bitter = LittleEndianBits::new(&[0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2]);
+        let mut bitter = LittleEndianReader::new(&[0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2]);
         assert_eq!(bitter.read_u8(), Some(0xff));
         assert_eq!(bitter.read_u8(), Some(0xfe));
         assert_eq!(bitter.read_u8(), Some(0xfa));
@@ -1232,7 +1232,7 @@ mod tests {
 
     #[test]
     fn test_u8_unchecked_reads() {
-        let mut bitter = LittleEndianBits::new(&[0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2]);
+        let mut bitter = LittleEndianReader::new(&[0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2]);
         assert_eq!(bitter.read_u8_unchecked(), 0xff);
         assert_eq!(bitter.read_u8_unchecked(), 0xfe);
         assert_eq!(bitter.read_u8_unchecked(), 0xfa);
@@ -1246,7 +1246,7 @@ mod tests {
 
     #[test]
     fn test_u64_reads() {
-        let mut bitter = LittleEndianBits::new(&[
+        let mut bitter = LittleEndianReader::new(&[
             0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2, 0x01, 0xff, 0xfe, 0xfa, 0xf7, 0xf5,
             0xf0, 0xb1, 0xb3,
         ]);
@@ -1257,7 +1257,7 @@ mod tests {
 
     #[test]
     fn test_u64_unchecked_reads() {
-        let mut bitter = LittleEndianBits::new(&[
+        let mut bitter = LittleEndianReader::new(&[
             0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2, 0x01, 0xff, 0xfe, 0xfa, 0xf7, 0xf5,
             0xf0, 0xb1, 0xb3,
         ]);
@@ -1268,7 +1268,7 @@ mod tests {
 
     #[test]
     fn test_i64_unchecked_reads() {
-        let mut bitter = LittleEndianBits::new(&[
+        let mut bitter = LittleEndianReader::new(&[
             0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2, 0x01, 0xff, 0xfe, 0xfa, 0xf7, 0xf5,
             0xf0, 0xb1, 0xb3,
         ]);
@@ -1288,13 +1288,13 @@ mod tests {
 
     #[test]
     fn test_u32_bit_read() {
-        let mut bitter = LittleEndianBits::new(&[0xff, 0x00, 0xab, 0xcd]);
+        let mut bitter = LittleEndianReader::new(&[0xff, 0x00, 0xab, 0xcd]);
         assert_eq!(bitter.read_u32_bits(32), Some(0xcdab00ff));
     }
 
     #[test]
     fn test_u32_reads() {
-        let mut bitter = LittleEndianBits::new(&[
+        let mut bitter = LittleEndianReader::new(&[
             0xff,
             0x00,
             0xab,
@@ -1314,7 +1314,7 @@ mod tests {
 
     #[test]
     fn test_f32_reads() {
-        let mut bitter = LittleEndianBits::new(&[
+        let mut bitter = LittleEndianReader::new(&[
             0b0111_1011,
             0b0001_0100,
             0b1010_1110,
@@ -1332,7 +1332,7 @@ mod tests {
 
     #[test]
     fn test_f32_unchecked_reads() {
-        let mut bitter = LittleEndianBits::new(&[
+        let mut bitter = LittleEndianReader::new(&[
             0b0111_1011,
             0b0001_0100,
             0b1010_1110,
@@ -1350,7 +1350,7 @@ mod tests {
 
     #[test]
     fn test_u32_bits() {
-        let mut bitter = LittleEndianBits::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee]);
+        let mut bitter = LittleEndianReader::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee]);
         assert_eq!(bitter.read_u32_bits(10), Some(0x1ff));
         assert_eq!(bitter.read_u32_bits(10), Some(0x3b7));
         assert_eq!(bitter.read_u32_bits(10), Some(0x3fe));
@@ -1360,7 +1360,7 @@ mod tests {
 
     #[test]
     fn test_u32_unchecked() {
-        let mut bitter = LittleEndianBits::new(&[
+        let mut bitter = LittleEndianReader::new(&[
             0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
         ]);
         assert_eq!(bitter.read_u32_unchecked(), 0xffff_ffff);
@@ -1371,7 +1371,7 @@ mod tests {
     #[test]
     fn test_u32_bits_unchecked() {
         let mut bitter =
-            LittleEndianBits::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee, 0xaa, 0xbb, 0xcc, 0xdd]);
+            LittleEndianReader::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee, 0xaa, 0xbb, 0xcc, 0xdd]);
         assert_eq!(bitter.read_u32_bits_unchecked(10), 0x1ff);
         assert_eq!(bitter.read_u32_bits_unchecked(10), 0x3b7);
         assert_eq!(bitter.read_u32_bits_unchecked(10), 0x3fe);
@@ -1386,7 +1386,7 @@ mod tests {
 
     #[test]
     fn test_u32_bits_unchecked2() {
-        let mut bitter = LittleEndianBits::new(&[
+        let mut bitter = LittleEndianReader::new(&[
             0x9c, 0x73, 0xce, 0x39, 0xe7, 0x9c, 0x73, 0xce, 0x39, 0xe7, 0x9c, 0x73, 0xce, 0x39,
             0xe7,
         ]);
@@ -1398,7 +1398,7 @@ mod tests {
     #[test]
     fn test_i32_bits_unchecked() {
         let mut bitter =
-            LittleEndianBits::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee, 0xaa, 0xbb, 0xcc, 0xdd]);
+            LittleEndianReader::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee, 0xaa, 0xbb, 0xcc, 0xdd]);
         assert_eq!(bitter.read_i32_bits_unchecked(10), 0x1ff);
         assert_eq!(bitter.read_i32_bits_unchecked(10), 0x3b7);
         assert_eq!(bitter.read_i32_bits_unchecked(10), 0x3fe);
@@ -1413,7 +1413,7 @@ mod tests {
 
     #[test]
     fn test_u32_bits2() {
-        let mut bitter = LittleEndianBits::new(&[
+        let mut bitter = LittleEndianReader::new(&[
             0x9c, 0x73, 0xce, 0x39, 0xe7, 0x9c, 0x73, 0xce, 0x39, 0xe7, 0x9c, 0x73, 0xce, 0x39,
             0xe7,
         ]);
@@ -1424,7 +1424,7 @@ mod tests {
 
     #[test]
     fn test_i32_bits2() {
-        let mut bitter = LittleEndianBits::new(&[
+        let mut bitter = LittleEndianReader::new(&[
             0x9c, 0x73, 0xce, 0x39, 0xe7, 0x9c, 0x73, 0xce, 0x39, 0xe7, 0x9c, 0x73, 0xce, 0x39,
             0xe7,
         ]);
@@ -1447,55 +1447,55 @@ mod tests {
 
     #[test]
     fn test_max_read() {
-        let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
+        let mut bitter = LittleEndianReader::new(&[0b1111_1000]);
         assert_eq!(bitter.read_bits_max(20), Some(8));
         assert_eq!(bitter.read_bits_max(20), Some(15));
         assert_eq!(bitter.read_bits_max(20), None);
 
-        let mut bitter = LittleEndianBits::new(&[0b1111_0000]);
+        let mut bitter = LittleEndianReader::new(&[0b1111_0000]);
         assert_eq!(bitter.read_bits_max(20), Some(16));
         assert_eq!(bitter.read_bits_max(20), None);
 
-        let mut bitter = LittleEndianBits::new(&[0b1110_0010]);
+        let mut bitter = LittleEndianReader::new(&[0b1110_0010]);
         assert_eq!(bitter.read_bits_max(20), Some(2));
 
-        let mut bitter = LittleEndianBits::new(&[0b0001_0100]);
+        let mut bitter = LittleEndianReader::new(&[0b0001_0100]);
         assert_eq!(bitter.read_bits_max(20), Some(4));
 
-        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianReader::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max(20), Some(19));
 
-        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianReader::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max(0), Some(0));
 
-        let mut bitter = LittleEndianBits::new(&[0xff, 0xff, 0xff, 0xff]);
+        let mut bitter = LittleEndianReader::new(&[0xff, 0xff, 0xff, 0xff]);
         assert_eq!(bitter.read_bits_max(u32::max_value()), Some(0x7fff_ffff));
     }
 
     #[test]
     fn test_max_read_computed() {
-        let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
+        let mut bitter = LittleEndianReader::new(&[0b1111_1000]);
         assert_eq!(bitter.read_bits_max_computed(4, 20), Some(8));
         assert_eq!(bitter.read_bits_max_computed(4, 20), Some(15));
         assert_eq!(bitter.read_bits_max_computed(4, 20), None);
 
-        let mut bitter = LittleEndianBits::new(&[0b1111_0000]);
+        let mut bitter = LittleEndianReader::new(&[0b1111_0000]);
         assert_eq!(bitter.read_bits_max_computed(4, 20), Some(16));
         assert_eq!(bitter.read_bits_max_computed(4, 20), None);
 
-        let mut bitter = LittleEndianBits::new(&[0b1110_0010]);
+        let mut bitter = LittleEndianReader::new(&[0b1110_0010]);
         assert_eq!(bitter.read_bits_max_computed(4, 20), Some(2));
 
-        let mut bitter = LittleEndianBits::new(&[0b0001_0100]);
+        let mut bitter = LittleEndianReader::new(&[0b0001_0100]);
         assert_eq!(bitter.read_bits_max_computed(4, 20), Some(4));
 
-        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianReader::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max_computed(4, 20), Some(19));
 
-        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianReader::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max_computed(0, 00), Some(0));
 
-        let mut bitter = LittleEndianBits::new(&[0xff, 0xff, 0xff, 0xff]);
+        let mut bitter = LittleEndianReader::new(&[0xff, 0xff, 0xff, 0xff]);
         assert_eq!(
             bitter.read_bits_max_computed(31, u32::max_value()),
             Some(0x7fff_ffff)
@@ -1504,26 +1504,26 @@ mod tests {
 
     #[test]
     fn test_max_read_unchecked() {
-        let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
+        let mut bitter = LittleEndianReader::new(&[0b1111_1000]);
         assert_eq!(bitter.read_bits_max_unchecked(20), 8);
         assert_eq!(bitter.read_bits_max_unchecked(20), 15);
 
-        let mut bitter = LittleEndianBits::new(&[0b1111_0000]);
+        let mut bitter = LittleEndianReader::new(&[0b1111_0000]);
         assert_eq!(bitter.read_bits_max_unchecked(20), 16);
 
-        let mut bitter = LittleEndianBits::new(&[0b1110_0010]);
+        let mut bitter = LittleEndianReader::new(&[0b1110_0010]);
         assert_eq!(bitter.read_bits_max_unchecked(20), 2);
 
-        let mut bitter = LittleEndianBits::new(&[0b0001_0100]);
+        let mut bitter = LittleEndianReader::new(&[0b0001_0100]);
         assert_eq!(bitter.read_bits_max_unchecked(20), 4);
 
-        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianReader::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max_unchecked(20), 19);
 
-        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianReader::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max_unchecked(0), 0);
 
-        let mut bitter = LittleEndianBits::new(&[0xff, 0xff, 0xff, 0xff]);
+        let mut bitter = LittleEndianReader::new(&[0xff, 0xff, 0xff, 0xff]);
         assert_eq!(
             bitter.read_bits_max_unchecked(u32::max_value()),
             0x7fff_ffff
@@ -1532,26 +1532,26 @@ mod tests {
 
     #[test]
     fn test_max_read_unchecked_computed() {
-        let mut bitter = LittleEndianBits::new(&[0b1111_1000]);
+        let mut bitter = LittleEndianReader::new(&[0b1111_1000]);
         assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 8);
         assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 15);
 
-        let mut bitter = LittleEndianBits::new(&[0b1111_0000]);
+        let mut bitter = LittleEndianReader::new(&[0b1111_0000]);
         assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 16);
 
-        let mut bitter = LittleEndianBits::new(&[0b1110_0010]);
+        let mut bitter = LittleEndianReader::new(&[0b1110_0010]);
         assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 2);
 
-        let mut bitter = LittleEndianBits::new(&[0b0001_0100]);
+        let mut bitter = LittleEndianReader::new(&[0b0001_0100]);
         assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 4);
 
-        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianReader::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max_computed_unchecked(4, 20), 19);
 
-        let mut bitter = LittleEndianBits::new(&[0b0001_0011]);
+        let mut bitter = LittleEndianReader::new(&[0b0001_0011]);
         assert_eq!(bitter.read_bits_max_computed_unchecked(0, 0), 0);
 
-        let mut bitter = LittleEndianBits::new(&[0xff, 0xff, 0xff, 0xff]);
+        let mut bitter = LittleEndianReader::new(&[0xff, 0xff, 0xff, 0xff]);
         assert_eq!(
             bitter.read_bits_max_computed_unchecked(31, u32::max_value()),
             0x7fff_ffff
@@ -1560,28 +1560,28 @@ mod tests {
 
     #[test]
     fn test_if_get() {
-        let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
-        assert_eq!(bitter.if_get(LittleEndianBits::read_u8), Some(Some(0x7f)));
-        assert_eq!(bitter.if_get(LittleEndianBits::read_u8), Some(None));
-        assert_eq!(bitter.if_get(LittleEndianBits::read_u8), None);
+        let mut bitter = LittleEndianReader::new(&[0xff, 0x04]);
+        assert_eq!(bitter.if_get(LittleEndianReader::read_u8), Some(Some(0x7f)));
+        assert_eq!(bitter.if_get(LittleEndianReader::read_u8), Some(None));
+        assert_eq!(bitter.if_get(LittleEndianReader::read_u8), None);
     }
 
     #[test]
     fn test_if_get_unchecked() {
-        let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
+        let mut bitter = LittleEndianReader::new(&[0xff, 0x04]);
         assert_eq!(
-            bitter.if_get_unchecked(LittleEndianBits::read_u8_unchecked),
+            bitter.if_get_unchecked(LittleEndianReader::read_u8_unchecked),
             Some(0x7f)
         );
         assert_eq!(
-            bitter.if_get_unchecked(LittleEndianBits::read_u8_unchecked),
+            bitter.if_get_unchecked(LittleEndianReader::read_u8_unchecked),
             None
         );
     }
 
     #[test]
     fn test_approx_bytes_and_empty() {
-        let mut bitter = LittleEndianBits::new(&[0xff, 0x04]);
+        let mut bitter = LittleEndianReader::new(&[0xff, 0x04]);
         assert!(!bitter.is_empty());
         assert_eq!(bitter.approx_bytes_remaining(), 2);
         assert!(bitter.read_bit().is_some());
@@ -1604,14 +1604,14 @@ mod tests {
     #[test]
     fn has_bits_remaining_max() {
         let data = vec![];
-        let bits = LittleEndianBits::new(data.as_slice());
+        let bits = LittleEndianReader::new(data.as_slice());
         assert_eq!(false, bits.has_bits_remaining(usize::max_value()));
     }
 
     #[test]
     fn i16_test() {
         let data = [0b1111_1111, 0b1111_1111];
-        let mut bits = LittleEndianBits::new(&data[..]);
+        let mut bits = LittleEndianReader::new(&data[..]);
 
         assert_eq!(bits.read_i16(), Some(i16::from_le_bytes(data)));
     }
@@ -1619,7 +1619,7 @@ mod tests {
     #[test]
     fn i16_min_test() {
         let data = [0b0000_0000, 0b1000_0000];
-        let mut bits = LittleEndianBits::new(&data[..]);
+        let mut bits = LittleEndianReader::new(&data[..]);
 
         assert_eq!(bits.read_i16(), Some(core::i16::MIN));
     }
@@ -1627,7 +1627,7 @@ mod tests {
     #[test]
     fn i16_max_test() {
         let data = [0b1111_1111, 0b0111_1111];
-        let mut bits = LittleEndianBits::new(&data[..]);
+        let mut bits = LittleEndianReader::new(&data[..]);
 
         assert_eq!(bits.read_i16(), Some(core::i16::MAX));
     }
@@ -1637,7 +1637,7 @@ mod tests {
         let mut data = Vec::new();
         data.extend_from_slice(&(1u64.to_le_bytes()));
         data.extend_from_slice(&(0u64.to_le_bytes()));
-        let mut bits = LittleEndianBits::new(data.as_slice());
+        let mut bits = LittleEndianReader::new(data.as_slice());
         assert_eq!(bits.read_u64(), Some(1));
         assert_eq!(bits.read_u64(), Some(0));
     }
@@ -1647,7 +1647,7 @@ mod tests {
         let mut data = Vec::new();
         data.extend_from_slice(&(0u64.to_le_bytes()));
         data.extend_from_slice(&(1u64.to_le_bytes()));
-        let mut bits = LittleEndianBits::new(data.as_slice());
+        let mut bits = LittleEndianReader::new(data.as_slice());
         for _ in 0..8 {
             assert_eq!(bits.read_u8(), Some(0));
         }
@@ -1659,7 +1659,7 @@ mod tests {
         let mut data = Vec::new();
         data.extend_from_slice(&(0u64.to_le_bytes()));
         data.extend_from_slice(&(1u64.to_le_bytes()));
-        let mut bits = LittleEndianBits::new(data.as_slice());
+        let mut bits = LittleEndianReader::new(data.as_slice());
         for _ in 0..8 {
             assert_eq!(bits.read_u8_unchecked(), 0);
         }
@@ -1669,7 +1669,7 @@ mod tests {
     #[test]
     fn regression1() {
         let data = vec![0b0000_0010, 0b0011_1111, 0b1011_1100];
-        let mut bits = LittleEndianBits::new(data.as_slice());
+        let mut bits = LittleEndianReader::new(data.as_slice());
 
         assert_eq!(bits.read_u32_bits(3), Some(2));
         assert_eq!(bits.read_u8(), Some(224));
@@ -1680,7 +1680,7 @@ mod tests {
     #[test]
     fn regression2() {
         let data = vec![2, 63, 63, 2, 63, 2, 0, 0, 0];
-        let mut bits = LittleEndianBits::new(data.as_slice());
+        let mut bits = LittleEndianReader::new(data.as_slice());
 
         assert_eq!(bits.read_u32_bits(3), Some(2));
         assert_eq!(bits.read_u8(), Some(224));
@@ -1690,11 +1690,11 @@ mod tests {
 
 #[cfg(test)]
 mod be_tests {
-    use super::{BigEndianBits, BitReader};
+    use super::{BigEndianReader, BitReader};
 
     #[test]
     fn test_be_bit_bits_reads() {
-        let mut bitter = BigEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = BigEndianReader::new(&[0b1010_1010, 0b0101_0101]);
         assert!(bitter.has_bits_remaining(16));
         assert_eq!(bitter.bits_remaining(), Some(16));
         assert_eq!(bitter.read_u32_bits(1), Some(1));
@@ -1721,7 +1721,7 @@ mod be_tests {
 
     #[test]
     fn test_whole_bytes() {
-        let mut bitter = BigEndianBits::new(&[
+        let mut bitter = BigEndianReader::new(&[
             0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee, 0xaa, 0xbb, 0xcc, 0xdd, 0xff, 0xdd, 0xee, 0xff,
             0xdd,
         ]);
@@ -1742,7 +1742,7 @@ mod be_tests {
     #[test]
     fn test_u32_bits() {
         let mut bitter =
-            BigEndianBits::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee, 0xaa, 0xbb, 0xcc, 0xdd]);
+            BigEndianReader::new(&[0xff, 0xdd, 0xee, 0xff, 0xdd, 0xee, 0xaa, 0xbb, 0xcc, 0xdd]);
         assert_eq!(bitter.read_u32_bits(10), Some(0b11_1111_1111));
         assert_eq!(bitter.read_u32_bits(10), Some(0b01_1101_1110));
         assert_eq!(bitter.read_u32_bits(10), Some(0b11_1011_1111));
@@ -1757,7 +1757,7 @@ mod be_tests {
 
     #[test]
     fn test_u32_bits2() {
-        let mut bitter = BigEndianBits::new(&[
+        let mut bitter = BigEndianReader::new(&[
             0b1110_0111,
             0b0011_1001,
             0b1100_1110,
@@ -1776,7 +1776,7 @@ mod be_tests {
 
     #[test]
     fn test_bit_unchecked_bits_reads() {
-        let mut bitter = BigEndianBits::new(&[0b1010_1010, 0b0101_0101]);
+        let mut bitter = BigEndianReader::new(&[0b1010_1010, 0b0101_0101]);
         assert_eq!(bitter.read_u32_bits_unchecked(1), 1);
         assert_eq!(bitter.read_u32_bits_unchecked(1), 0);
         assert_eq!(bitter.read_u32_bits_unchecked(1), 1);
@@ -1799,7 +1799,7 @@ mod be_tests {
 
     #[test]
     fn test_u64_unchecked_reads() {
-        let mut bitter = BigEndianBits::new(&[
+        let mut bitter = BigEndianReader::new(&[
             0xff, 0xfe, 0xfa, 0xf7, 0xf5, 0xf0, 0xb1, 0xb2, 0x01, 0xff, 0xfe, 0xfa, 0xf7, 0xf5,
             0xf0, 0xb1, 0xb3,
         ]);
@@ -1816,7 +1816,7 @@ mod be_tests {
 
     #[test]
     fn test_u32_bit_read() {
-        let mut bitter = BigEndianBits::new(&[0xff, 0x00, 0xab, 0xcd]);
+        let mut bitter = BigEndianReader::new(&[0xff, 0x00, 0xab, 0xcd]);
         assert_eq!(bitter.read_u32_bits(32), Some(0xff00abcd));
     }
 
@@ -1825,7 +1825,7 @@ mod be_tests {
         let mut data = Vec::new();
         data.extend_from_slice(&(0u64.to_be_bytes()));
         data.extend_from_slice(&(1u64.to_be_bytes()));
-        let mut bits = BigEndianBits::new(data.as_slice());
+        let mut bits = BigEndianReader::new(data.as_slice());
         assert_eq!(bits.read_u64(), Some(0));
         assert_eq!(bits.read_u64(), Some(1));
     }
@@ -1835,7 +1835,7 @@ mod be_tests {
         let mut data = Vec::new();
         data.extend_from_slice(&(1u64.to_be_bytes()));
         data.extend_from_slice(&(0u64.to_be_bytes()));
-        let mut bits = BigEndianBits::new(data.as_slice());
+        let mut bits = BigEndianReader::new(data.as_slice());
         assert_eq!(bits.read_u64(), Some(1));
         assert_eq!(bits.read_u64(), Some(0));
     }
@@ -1845,7 +1845,7 @@ mod be_tests {
         let mut data = Vec::new();
         data.extend_from_slice(&(0u64.to_be_bytes()));
         data.extend_from_slice(&(1u64.to_be_bytes()));
-        let mut bits = BigEndianBits::new(data.as_slice());
+        let mut bits = BigEndianReader::new(data.as_slice());
         for _ in 0..8 {
             assert_eq!(bits.read_u8(), Some(0));
         }
@@ -1857,7 +1857,7 @@ mod be_tests {
         let mut data = Vec::new();
         data.extend_from_slice(&(0u64.to_be_bytes()));
         data.extend_from_slice(&(1u64.to_be_bytes()));
-        let mut bits = BigEndianBits::new(data.as_slice());
+        let mut bits = BigEndianReader::new(data.as_slice());
         assert_eq!(bits.read_u64_unchecked(), 0);
         assert_eq!(bits.read_u64_unchecked(), 1);
     }
@@ -1867,7 +1867,7 @@ mod be_tests {
         let mut data = Vec::new();
         data.extend_from_slice(&(1u64.to_be_bytes()));
         data.extend_from_slice(&(0u64.to_be_bytes()));
-        let mut bits = BigEndianBits::new(data.as_slice());
+        let mut bits = BigEndianReader::new(data.as_slice());
         assert_eq!(bits.read_u64_unchecked(), 1);
         assert_eq!(bits.read_u64_unchecked(), 0);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -833,7 +833,14 @@ impl<'a> LittleEndianBits<'a> {
             if new_data.len() < BYTE_WIDTH && left > new_data.len() * 8 {
                 None
             } else {
-                let little = self.current_val.wrapping_shr(self.pos as u32);
+                let little = self.current_val.checked_shr(self.pos as u32).unwrap_or(0);
+                // let pos_mask = self.pos & 63;
+                // let little = self.current_val >> pos_mask;
+                // let overflowed = (self.pos != pos_mask) as i64;
+                // let overflowed = unsafe { std::mem::transmute::<i64, u64>(-overflowed) };
+                // let little_mask = u64::MAX;
+                // let little = (little & !little_mask) | (overflowed & little_mask);
+
                 self.data = new_data;
                 self.current_val = self.read();
                 let big = (self.current_val & bit_mask(left)) << (bts - left);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -892,7 +892,12 @@ impl<'a> LittleEndianBits<'a> {
             result
         } else {
             let bts = core::mem::size_of::<u64>() * 8;
-            let little = self.current_val >> self.pos;
+            let pos_mask = self.pos & 63;
+            let little = self.current_val >> pos_mask;
+            let no_overflow = (self.pos == pos_mask) as i64;
+            let no_overflow = unsafe { std::mem::transmute::<i64, u64>(-no_overflow) };
+            let little = no_overflow & little;
+
             self.data = &self.data[BYTE_WIDTH..];
             self.current_val = self.read();
             let big = self.current_val << (bts - self.pos);
@@ -993,7 +998,12 @@ impl<'a> BigEndianBits<'a> {
             result
         } else {
             let bts = core::mem::size_of::<u64>() * 8;
-            let big = self.current_val << self.pos;
+            let pos_mask = self.pos & 63;
+            let big = self.current_val << pos_mask;
+            let no_overflow = (self.pos == pos_mask) as i64;
+            let no_overflow = unsafe { std::mem::transmute::<i64, u64>(-no_overflow) };
+            let big = no_overflow & big;
+
             self.data = &self.data[BYTE_WIDTH..];
             self.current_val = self.read();
             let little = self.current_val >> (bts - self.pos);

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -61,36 +61,48 @@ fn v1_eq(data: Vec<u8>) -> bool {
         && bits.read_u8() == bitsv1.read_u8()
 }
 
-#[quickcheck]
-fn read_byte_eq(data: Vec<u8>) -> bool {
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = BigEndianBits::new(data.as_slice());
+// #[quickcheck]
+// fn read_byte_eq(data: Vec<u8>) -> bool {
+//     let mut lebits = LittleEndianBits::new(data.as_slice());
+//     let mut bebits = BigEndianBits::new(data.as_slice());
 
-    lebits.read_u8() == bebits.read_u8()
+//     for i in &data {
+//         if lebits.read_u8() != bebits.read_u8() {
+//             return false;
+//         }
+//     }
+
+//     lebits.is_empty() && bebits.is_empty()
+// }
+
+#[quickcheck]
+fn read_u16_eq(x: u16) -> bool {
+    let le_data = x.to_le_bytes();
+    let be_data = x.to_be_bytes();
+    let mut lebits = LittleEndianBits::new(&le_data);
+    let mut bebits = BigEndianBits::new(&be_data);
+
+    lebits.read_u16() == bebits.read_u16()
 }
 
 #[quickcheck]
-fn read_u16_eq(data: Vec<u8>) -> bool {
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = BigEndianBits::new(data.as_slice());
+fn read_u32_eq(x: u32) -> bool {
+    let le_data = x.to_le_bytes();
+    let be_data = x.to_be_bytes();
+    let mut lebits = LittleEndianBits::new(&le_data);
+    let mut bebits = BigEndianBits::new(&be_data);
 
-    lebits.read_u16().map(|x| x.to_be()) == bebits.read_u16()
+    lebits.read_u32() == bebits.read_u32()
 }
 
 #[quickcheck]
-fn read_u32_eq(data: Vec<u8>) -> bool {
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = BigEndianBits::new(data.as_slice());
+fn read_u64_eq(x: u64) -> bool {
+    let le_data = x.to_le_bytes();
+    let be_data = x.to_be_bytes();
+    let mut lebits = LittleEndianBits::new(&le_data);
+    let mut bebits = BigEndianBits::new(&be_data);
 
-    lebits.read_u32().map(|x| x.to_be()) == bebits.read_u32()
-}
-
-#[quickcheck]
-fn read_u64_eq(data: Vec<u8>) -> bool {
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = BigEndianBits::new(data.as_slice());
-
-    lebits.read_u64().map(|x| x.to_be()) == bebits.read_u64()
+    lebits.read_u64() == bebits.read_u64()
 }
 
 #[quickcheck]

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -4,7 +4,7 @@ extern crate quickcheck_macros;
 extern crate bitter;
 extern crate bitterv1;
 
-use bitter::{BigEndianBits, BitOrder, LittleEndianBits};
+use bitter::{BigEndianBits, BitReader, LittleEndianBits};
 
 #[quickcheck]
 fn read_bytes_eq(k1: u8, data: Vec<u8>) -> bool {
@@ -135,7 +135,7 @@ fn read_u64_unchecked_eq(data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn has_bits_remaining_bit_reads_ends(reads: u8, data: Vec<u8>) -> bool {
-    fn test_fn<B: BitOrder>(bits: &mut B, reads: u8) -> bool {
+    fn test_fn<B: BitReader>(bits: &mut B, reads: u8) -> bool {
         let mut result = true;
         if bits.has_bits_remaining(usize::from(reads)) {
             for _ in 0..reads {

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -4,11 +4,11 @@ extern crate quickcheck_macros;
 extern crate bitter;
 extern crate bitterv1;
 
-use bitter::{BigEndianBits, BitReader, LittleEndianBits};
+use bitter::{BigEndianReader, BitReader, LittleEndianReader};
 
 #[quickcheck]
 fn read_bytes_eq(k1: u8, data: Vec<u8>) -> bool {
-    let mut bits = LittleEndianBits::new(data.as_slice());
+    let mut bits = LittleEndianReader::new(data.as_slice());
     let mut buf = vec![0u8; usize::from(k1)];
     if !bits.read_bytes(&mut buf) {
         k1 > data.len() as u8
@@ -19,19 +19,19 @@ fn read_bytes_eq(k1: u8, data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn has_bits_remaining_bit_reads(data: Vec<u8>) -> bool {
-    let mut bits = LittleEndianBits::new(data.as_slice());
+    let mut bits = LittleEndianReader::new(data.as_slice());
     (1..128).all(|_x| bits.has_bits_remaining(1) == bits.read_bit().is_some())
 }
 
 #[quickcheck]
 fn has_bits_remaining_be_bit_reads(data: Vec<u8>) -> bool {
-    let mut bits = BigEndianBits::new(data.as_slice());
+    let mut bits = BigEndianReader::new(data.as_slice());
     (1..128).all(|_x| bits.has_bits_remaining(1) == bits.read_bit().is_some())
 }
 
 #[quickcheck]
 fn has_bits_remaining(data: Vec<u8>) -> bool {
-    let mut bits = LittleEndianBits::new(data.as_slice());
+    let mut bits = LittleEndianReader::new(data.as_slice());
     (1..32).all(|x| bits.has_bits_remaining(x) == bits.read_u32_bits(x as i32).is_some())
         && bits.has_bits_remaining(8) == bits.read_u8().is_some()
         && bits.has_bits_remaining(16) == bits.read_u16().is_some()
@@ -45,7 +45,7 @@ fn read_bytes_bits(data: Vec<u8>) -> bool {
         return true;
     }
 
-    let mut bits = LittleEndianBits::new(data.as_slice());
+    let mut bits = LittleEndianReader::new(data.as_slice());
     bits.read_u32_bits_unchecked(3);
 
     let mut buf = vec![0u8; data.len() - 1];
@@ -54,7 +54,7 @@ fn read_bytes_bits(data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn v1_eq(data: Vec<u8>) -> bool {
-    let mut bits = LittleEndianBits::new(data.as_slice());
+    let mut bits = LittleEndianReader::new(data.as_slice());
     let mut bitsv1 = bitterv1::BitGet::new(data.as_slice());
     let mut buf = vec![0u8; 3];
 
@@ -69,8 +69,8 @@ fn v1_eq(data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn read_byte_eq(data: Vec<u8>) -> bool {
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = BigEndianBits::new(data.as_slice());
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+    let mut bebits = BigEndianReader::new(data.as_slice());
 
     for _ in &data {
         if lebits.read_u8() != bebits.read_u8() {
@@ -83,8 +83,8 @@ fn read_byte_eq(data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn read_byte_unchecked_eq(data: Vec<u8>) -> bool {
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = BigEndianBits::new(data.as_slice());
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+    let mut bebits = BigEndianReader::new(data.as_slice());
 
     for _ in &data {
         if lebits.read_u8_unchecked() != bebits.read_u8_unchecked() {
@@ -97,8 +97,8 @@ fn read_byte_unchecked_eq(data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn read_byte_alternate(data: Vec<u8>) -> bool {
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = BigEndianBits::new(data.as_slice());
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+    let mut bebits = BigEndianReader::new(data.as_slice());
 
     for (i, x) in data.iter().enumerate() {
         if i % 3 == 0 {
@@ -123,7 +123,7 @@ fn read_u64_le_alternate(data: Vec<u64>) -> bool {
     for x in &data {
         ledata.extend_from_slice(&x.to_le_bytes());
     }
-    let mut lebits = LittleEndianBits::new(ledata.as_slice());
+    let mut lebits = LittleEndianReader::new(ledata.as_slice());
     for _ in 0..64 {
         lebits.read_bit();
     }
@@ -149,7 +149,7 @@ fn read_u64_be_alternate(data: Vec<u64>) -> bool {
     for x in &data {
         bedata.extend_from_slice(&x.to_be_bytes());
     }
-    let mut bebits = BigEndianBits::new(bedata.as_slice());
+    let mut bebits = BigEndianReader::new(bedata.as_slice());
     for _ in 0..64 {
         bebits.read_bit();
     }
@@ -173,8 +173,8 @@ fn read_u64_be_alternate(data: Vec<u64>) -> bool {
 fn read_u16_eq(x: u16) -> bool {
     let le_data = x.to_le_bytes();
     let be_data = x.to_be_bytes();
-    let mut lebits = LittleEndianBits::new(&le_data);
-    let mut bebits = BigEndianBits::new(&be_data);
+    let mut lebits = LittleEndianReader::new(&le_data);
+    let mut bebits = BigEndianReader::new(&be_data);
 
     lebits.read_u16() == bebits.read_u16()
 }
@@ -183,8 +183,8 @@ fn read_u16_eq(x: u16) -> bool {
 fn read_u32_eq(x: u32) -> bool {
     let le_data = x.to_le_bytes();
     let be_data = x.to_be_bytes();
-    let mut lebits = LittleEndianBits::new(&le_data);
-    let mut bebits = BigEndianBits::new(&be_data);
+    let mut lebits = LittleEndianReader::new(&le_data);
+    let mut bebits = BigEndianReader::new(&be_data);
 
     lebits.read_u32() == bebits.read_u32()
 }
@@ -193,16 +193,16 @@ fn read_u32_eq(x: u32) -> bool {
 fn read_u64_eq(x: u64) -> bool {
     let le_data = x.to_le_bytes();
     let be_data = x.to_be_bytes();
-    let mut lebits = LittleEndianBits::new(&le_data);
-    let mut bebits = BigEndianBits::new(&be_data);
+    let mut lebits = LittleEndianReader::new(&le_data);
+    let mut bebits = BigEndianReader::new(&be_data);
 
     lebits.read_u64() == bebits.read_u64()
 }
 
 #[quickcheck]
 fn read_u16_unchecked_eq(data: Vec<u8>) -> bool {
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = BigEndianBits::new(data.as_slice());
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+    let mut bebits = BigEndianReader::new(data.as_slice());
 
     lebits.has_bits_remaining(16) == bebits.has_bits_remaining(16)
         && (!lebits.has_bits_remaining(16)
@@ -211,8 +211,8 @@ fn read_u16_unchecked_eq(data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn read_u32_unchecked_eq(data: Vec<u8>) -> bool {
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = BigEndianBits::new(data.as_slice());
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+    let mut bebits = BigEndianReader::new(data.as_slice());
 
     lebits.has_bits_remaining(32) == bebits.has_bits_remaining(32)
         && (!lebits.has_bits_remaining(32)
@@ -221,8 +221,8 @@ fn read_u32_unchecked_eq(data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn read_u64_unchecked_eq(data: Vec<u8>) -> bool {
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = BigEndianBits::new(data.as_slice());
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+    let mut bebits = BigEndianReader::new(data.as_slice());
 
     lebits.has_bits_remaining(64) == bebits.has_bits_remaining(64)
         && (!lebits.has_bits_remaining(64)
@@ -242,8 +242,8 @@ fn has_bits_remaining_bit_reads_ends(reads: u8, data: Vec<u8>) -> bool {
         result
     }
 
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = LittleEndianBits::new(data.as_slice());
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+    let mut bebits = LittleEndianReader::new(data.as_slice());
 
     test_fn(&mut lebits, reads) && test_fn(&mut bebits, reads)
 }
@@ -253,8 +253,8 @@ fn read_u32_val_eq(bits: u32) -> bool {
     let le_data = bits.to_le_bytes();
     let be_data = bits.to_be_bytes();
 
-    let mut lebits = LittleEndianBits::new(&le_data);
-    let mut bebits = BigEndianBits::new(&be_data);
+    let mut lebits = LittleEndianReader::new(&le_data);
+    let mut bebits = BigEndianReader::new(&be_data);
 
     lebits.read_u32() == bebits.read_u32()
 }
@@ -264,8 +264,8 @@ fn read_u32_unchecked_val_eq(bits: u32) -> bool {
     let le_data = bits.to_le_bytes();
     let be_data = bits.to_be_bytes();
 
-    let mut lebits = LittleEndianBits::new(&le_data);
-    let mut bebits = BigEndianBits::new(&be_data);
+    let mut lebits = LittleEndianReader::new(&le_data);
+    let mut bebits = BigEndianReader::new(&be_data);
 
     let le = lebits.read_u32_unchecked();
     le == bebits.read_u32_unchecked() && le == bits
@@ -276,8 +276,8 @@ fn read_f32_eq(bits: u32) -> bool {
     let le_data = bits.to_le_bytes();
     let be_data = bits.to_be_bytes();
 
-    let mut lebits = LittleEndianBits::new(&le_data);
-    let mut bebits = BigEndianBits::new(&be_data);
+    let mut lebits = LittleEndianReader::new(&le_data);
+    let mut bebits = BigEndianReader::new(&be_data);
 
     lebits.read_f32() == bebits.read_f32()
 }
@@ -287,8 +287,8 @@ fn read_f32_unchecked_eq(bits: u32) -> bool {
     let le_data = bits.to_le_bytes();
     let be_data = bits.to_be_bytes();
 
-    let mut lebits = LittleEndianBits::new(&le_data);
-    let mut bebits = BigEndianBits::new(&be_data);
+    let mut lebits = LittleEndianReader::new(&le_data);
+    let mut bebits = BigEndianReader::new(&be_data);
 
     lebits.read_f32_unchecked() == bebits.read_f32_unchecked()
 }
@@ -298,7 +298,7 @@ fn back_to_back_le_u64(x: u64, y: u64) -> bool {
     let mut data = Vec::new();
     data.extend_from_slice(&(x.to_le_bytes()));
     data.extend_from_slice(&(y.to_le_bytes()));
-    let mut bits = LittleEndianBits::new(data.as_slice());
+    let mut bits = LittleEndianReader::new(data.as_slice());
     bits.read_u64() == Some(x) && bits.read_u64() == Some(y)
 }
 
@@ -307,7 +307,7 @@ fn back_to_back_le_unchecked_u64(x: u64, y: u64) -> bool {
     let mut data = Vec::new();
     data.extend_from_slice(&(x.to_le_bytes()));
     data.extend_from_slice(&(y.to_le_bytes()));
-    let mut bits = LittleEndianBits::new(data.as_slice());
+    let mut bits = LittleEndianReader::new(data.as_slice());
     bits.read_u64_unchecked() == x && bits.read_u64_unchecked() == y
 }
 
@@ -316,7 +316,7 @@ fn back_to_back_be_u64(x: u64, y: u64) -> bool {
     let mut data = Vec::new();
     data.extend_from_slice(&(x.to_be_bytes()));
     data.extend_from_slice(&(y.to_be_bytes()));
-    let mut bits = BigEndianBits::new(data.as_slice());
+    let mut bits = BigEndianReader::new(data.as_slice());
     bits.read_u64() == Some(x) && bits.read_u64() == Some(y)
 }
 
@@ -325,6 +325,6 @@ fn back_to_back_be_unchecked_u64(x: u64, y: u64) -> bool {
     let mut data = Vec::new();
     data.extend_from_slice(&(x.to_be_bytes()));
     data.extend_from_slice(&(y.to_be_bytes()));
-    let mut bits = BigEndianBits::new(data.as_slice());
+    let mut bits = BigEndianReader::new(data.as_slice());
     bits.read_u64_unchecked() == x && bits.read_u64_unchecked() == y
 }

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -124,8 +124,11 @@ fn read_u64_le_alternate(data: Vec<u64>) -> bool {
         ledata.extend_from_slice(&x.to_le_bytes());
     }
     let mut lebits = LittleEndianBits::new(ledata.as_slice());
+    for _ in 0..64 {
+        lebits.read_bit();
+    }
 
-    for (i, x) in data.iter().enumerate() {
+    for (i, x) in data.iter().skip(1).enumerate() {
         if i % 3 == 0 {
             if lebits.read_u64().unwrap() != *x {
                 return false;
@@ -147,8 +150,11 @@ fn read_u64_be_alternate(data: Vec<u64>) -> bool {
         bedata.extend_from_slice(&x.to_be_bytes());
     }
     let mut bebits = BigEndianBits::new(bedata.as_slice());
+    for _ in 0..64 {
+        bebits.read_bit();
+    }
 
-    for (i, x) in data.iter().enumerate() {
+    for (i, x) in data.iter().skip(1).enumerate() {
         if i % 3 == 0 {
             if bebits.read_u64().unwrap() != *x {
                 return false;

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -4,11 +4,11 @@ extern crate quickcheck_macros;
 extern crate bitter;
 extern crate bitterv1;
 
-use bitter::BitOrder;
+use bitter::{BigEndianBits, BitOrder, LittleEndianBits};
 
 #[quickcheck]
 fn read_bytes_eq(k1: u8, data: Vec<u8>) -> bool {
-    let mut bits = bitter::LittleEndianBits::new(data.as_slice());
+    let mut bits = LittleEndianBits::new(data.as_slice());
     let mut buf = vec![0u8; usize::from(k1)];
     if !bits.read_bytes(&mut buf) {
         k1 > data.len() as u8
@@ -19,13 +19,13 @@ fn read_bytes_eq(k1: u8, data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn has_bits_remaining_bit_reads(data: Vec<u8>) -> bool {
-    let mut bits = bitter::LittleEndianBits::new(data.as_slice());
+    let mut bits = LittleEndianBits::new(data.as_slice());
     (1..128).all(|_x| bits.has_bits_remaining(1) == bits.read_bit().is_some())
 }
 
 #[quickcheck]
 fn has_bits_remaining(data: Vec<u8>) -> bool {
-    let mut bits = bitter::LittleEndianBits::new(data.as_slice());
+    let mut bits = LittleEndianBits::new(data.as_slice());
     (1..32).all(|x| bits.has_bits_remaining(x) == bits.read_u32_bits(x as i32).is_some())
         && bits.has_bits_remaining(8) == bits.read_u8().is_some()
         && bits.has_bits_remaining(16) == bits.read_u16().is_some()
@@ -39,7 +39,7 @@ fn read_bytes_bits(data: Vec<u8>) -> bool {
         return true;
     }
 
-    let mut bits = bitter::LittleEndianBits::new(data.as_slice());
+    let mut bits = LittleEndianBits::new(data.as_slice());
     bits.read_u32_bits_unchecked(3);
 
     let mut buf = vec![0u8; data.len() - 1];
@@ -48,7 +48,7 @@ fn read_bytes_bits(data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn v1_eq(data: Vec<u8>) -> bool {
-    let mut bits = bitter::LittleEndianBits::new(data.as_slice());
+    let mut bits = LittleEndianBits::new(data.as_slice());
     let mut bitsv1 = bitterv1::BitGet::new(data.as_slice());
     let mut buf = vec![0u8; 3];
 
@@ -59,4 +59,140 @@ fn v1_eq(data: Vec<u8>) -> bool {
         && (bits.read_bytes(&mut buf) == bitsv1.read_bytes(3).is_some())
         && bits.read_u32_bits(13) == bitsv1.read_u32_bits(13)
         && bits.read_u8() == bitsv1.read_u8()
+}
+
+#[quickcheck]
+fn read_byte_eq(data: Vec<u8>) -> bool {
+    let mut lebits = LittleEndianBits::new(data.as_slice());
+    let mut bebits = BigEndianBits::new(data.as_slice());
+
+    lebits.read_u8() == bebits.read_u8()
+}
+
+#[quickcheck]
+fn read_u16_eq(data: Vec<u8>) -> bool {
+    let mut lebits = LittleEndianBits::new(data.as_slice());
+    let mut bebits = BigEndianBits::new(data.as_slice());
+
+    lebits.read_u16().map(|x| x.to_be()) == bebits.read_u16()
+}
+
+#[quickcheck]
+fn read_u32_eq(data: Vec<u8>) -> bool {
+    let mut lebits = LittleEndianBits::new(data.as_slice());
+    let mut bebits = BigEndianBits::new(data.as_slice());
+
+    lebits.read_u32().map(|x| x.to_be()) == bebits.read_u32()
+}
+
+#[quickcheck]
+fn read_u64_eq(data: Vec<u8>) -> bool {
+    let mut lebits = LittleEndianBits::new(data.as_slice());
+    let mut bebits = BigEndianBits::new(data.as_slice());
+
+    lebits.read_u64().map(|x| x.to_be()) == bebits.read_u64()
+}
+
+#[quickcheck]
+fn read_byte_unchecked_eq(data: Vec<u8>) -> bool {
+    let mut lebits = LittleEndianBits::new(data.as_slice());
+    let mut bebits = BigEndianBits::new(data.as_slice());
+
+    lebits.has_bits_remaining(8) == bebits.has_bits_remaining(8)
+        && (!lebits.has_bits_remaining(8)
+            || lebits.read_u8_unchecked() == bebits.read_u8_unchecked())
+}
+
+#[quickcheck]
+fn read_u16_unchecked_eq(data: Vec<u8>) -> bool {
+    let mut lebits = LittleEndianBits::new(data.as_slice());
+    let mut bebits = BigEndianBits::new(data.as_slice());
+
+    lebits.has_bits_remaining(16) == bebits.has_bits_remaining(16)
+        && (!lebits.has_bits_remaining(16)
+            || lebits.read_u16_unchecked().to_be() == bebits.read_u16_unchecked())
+}
+
+#[quickcheck]
+fn read_u32_unchecked_eq(data: Vec<u8>) -> bool {
+    let mut lebits = LittleEndianBits::new(data.as_slice());
+    let mut bebits = BigEndianBits::new(data.as_slice());
+
+    lebits.has_bits_remaining(32) == bebits.has_bits_remaining(32)
+        && (!lebits.has_bits_remaining(32)
+            || lebits.read_u32_unchecked().to_be() == bebits.read_u32_unchecked())
+}
+
+#[quickcheck]
+fn read_u64_unchecked_eq(data: Vec<u8>) -> bool {
+    let mut lebits = LittleEndianBits::new(data.as_slice());
+    let mut bebits = BigEndianBits::new(data.as_slice());
+
+    lebits.has_bits_remaining(64) == bebits.has_bits_remaining(64)
+        && (!lebits.has_bits_remaining(64)
+            || lebits.read_u64_unchecked().to_be() == bebits.read_u64_unchecked())
+}
+
+#[quickcheck]
+fn has_bits_remaining_bit_reads_ends(reads: u8, data: Vec<u8>) -> bool {
+    fn test_fn<B: BitOrder>(bits: &mut B, reads: u8) -> bool {
+        let mut result = true;
+        if bits.has_bits_remaining(usize::from(reads)) {
+            for _ in 0..reads {
+                result &= bits.read_bit().is_some();
+            }
+        }
+
+        result
+    }
+
+    let mut lebits = LittleEndianBits::new(data.as_slice());
+    let mut bebits = LittleEndianBits::new(data.as_slice());
+
+    test_fn(&mut lebits, reads) && test_fn(&mut bebits, reads)
+}
+
+#[quickcheck]
+fn read_u32_val_eq(bits: u32) -> bool {
+    let le_data = bits.to_le_bytes();
+    let be_data = bits.to_be_bytes();
+
+    let mut lebits = LittleEndianBits::new(&le_data);
+    let mut bebits = BigEndianBits::new(&be_data);
+
+    lebits.read_u32() == bebits.read_u32()
+}
+
+#[quickcheck]
+fn read_u32_unchecked_val_eq(bits: u32) -> bool {
+    let le_data = bits.to_le_bytes();
+    let be_data = bits.to_be_bytes();
+
+    let mut lebits = LittleEndianBits::new(&le_data);
+    let mut bebits = BigEndianBits::new(&be_data);
+
+    let le = lebits.read_u32_unchecked();
+    le == bebits.read_u32_unchecked() && le == bits
+}
+
+#[quickcheck]
+fn read_f32_eq(bits: u32) -> bool {
+    let le_data = bits.to_le_bytes();
+    let be_data = bits.to_be_bytes();
+
+    let mut lebits = LittleEndianBits::new(&le_data);
+    let mut bebits = BigEndianBits::new(&be_data);
+
+    lebits.read_f32() == bebits.read_f32()
+}
+
+#[quickcheck]
+fn read_f32_unchecked_eq(bits: u32) -> bool {
+    let le_data = bits.to_le_bytes();
+    let be_data = bits.to_be_bytes();
+
+    let mut lebits = LittleEndianBits::new(&le_data);
+    let mut bebits = BigEndianBits::new(&be_data);
+
+    lebits.read_f32_unchecked() == bebits.read_f32_unchecked()
 }

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -24,6 +24,12 @@ fn has_bits_remaining_bit_reads(data: Vec<u8>) -> bool {
 }
 
 #[quickcheck]
+fn has_bits_remaining_be_bit_reads(data: Vec<u8>) -> bool {
+    let mut bits = BigEndianBits::new(data.as_slice());
+    (1..128).all(|_x| bits.has_bits_remaining(1) == bits.read_bit().is_some())
+}
+
+#[quickcheck]
 fn has_bits_remaining(data: Vec<u8>) -> bool {
     let mut bits = LittleEndianBits::new(data.as_slice());
     (1..32).all(|x| bits.has_bits_remaining(x) == bits.read_u32_bits(x as i32).is_some())

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -4,9 +4,11 @@ extern crate quickcheck_macros;
 extern crate bitter;
 extern crate bitterv1;
 
+use bitter::BitOrder;
+
 #[quickcheck]
 fn read_bytes_eq(k1: u8, data: Vec<u8>) -> bool {
-    let mut bits = bitter::BitGet::new(data.as_slice());
+    let mut bits = bitter::LittleEndianBits::new(data.as_slice());
     let mut buf = vec![0u8; usize::from(k1)];
     if !bits.read_bytes(&mut buf) {
         k1 > data.len() as u8
@@ -17,13 +19,13 @@ fn read_bytes_eq(k1: u8, data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn has_bits_remaining_bit_reads(data: Vec<u8>) -> bool {
-    let mut bits = bitter::BitGet::new(data.as_slice());
+    let mut bits = bitter::LittleEndianBits::new(data.as_slice());
     (1..128).all(|_x| bits.has_bits_remaining(1) == bits.read_bit().is_some())
 }
 
 #[quickcheck]
 fn has_bits_remaining(data: Vec<u8>) -> bool {
-    let mut bits = bitter::BitGet::new(data.as_slice());
+    let mut bits = bitter::LittleEndianBits::new(data.as_slice());
     (1..32).all(|x| bits.has_bits_remaining(x) == bits.read_u32_bits(x as i32).is_some())
         && bits.has_bits_remaining(8) == bits.read_u8().is_some()
         && bits.has_bits_remaining(16) == bits.read_u16().is_some()
@@ -37,7 +39,7 @@ fn read_bytes_bits(data: Vec<u8>) -> bool {
         return true;
     }
 
-    let mut bits = bitter::BitGet::new(data.as_slice());
+    let mut bits = bitter::LittleEndianBits::new(data.as_slice());
     bits.read_u32_bits_unchecked(3);
 
     let mut buf = vec![0u8; data.len() - 1];
@@ -46,7 +48,7 @@ fn read_bytes_bits(data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn v1_eq(data: Vec<u8>) -> bool {
-    let mut bits = bitter::BitGet::new(data.as_slice());
+    let mut bits = bitter::LittleEndianBits::new(data.as_slice());
     let mut bitsv1 = bitterv1::BitGet::new(data.as_slice());
     let mut buf = vec![0u8; 3];
 

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -200,33 +200,33 @@ fn read_u64_eq(x: u64) -> bool {
 }
 
 #[quickcheck]
-fn read_u16_unchecked_eq(data: Vec<u8>) -> bool {
-    let mut lebits = LittleEndianReader::new(data.as_slice());
-    let mut bebits = BigEndianReader::new(data.as_slice());
+fn read_u16_unchecked_eq(x: u16) -> bool {
+    let le_data = x.to_le_bytes();
+    let be_data = x.to_be_bytes();
+    let mut lebits = LittleEndianReader::new(&le_data);
+    let mut bebits = BigEndianReader::new(&be_data);
 
-    lebits.has_bits_remaining(16) == bebits.has_bits_remaining(16)
-        && (!lebits.has_bits_remaining(16)
-            || lebits.read_u16_unchecked().to_be() == bebits.read_u16_unchecked())
+    lebits.read_u16_unchecked() == bebits.read_u16_unchecked()
 }
 
 #[quickcheck]
-fn read_u32_unchecked_eq(data: Vec<u8>) -> bool {
-    let mut lebits = LittleEndianReader::new(data.as_slice());
-    let mut bebits = BigEndianReader::new(data.as_slice());
+fn read_u32_unchecked_eq(x: u32) -> bool {
+    let le_data = x.to_le_bytes();
+    let be_data = x.to_be_bytes();
+    let mut lebits = LittleEndianReader::new(&le_data);
+    let mut bebits = BigEndianReader::new(&be_data);
 
-    lebits.has_bits_remaining(32) == bebits.has_bits_remaining(32)
-        && (!lebits.has_bits_remaining(32)
-            || lebits.read_u32_unchecked().to_be() == bebits.read_u32_unchecked())
+    lebits.read_u32_unchecked() == bebits.read_u32_unchecked()
 }
 
 #[quickcheck]
-fn read_u64_unchecked_eq(data: Vec<u8>) -> bool {
-    let mut lebits = LittleEndianReader::new(data.as_slice());
-    let mut bebits = BigEndianReader::new(data.as_slice());
+fn read_u64_unchecked_eq(x: u64) -> bool {
+    let le_data = x.to_le_bytes();
+    let be_data = x.to_be_bytes();
+    let mut lebits = LittleEndianReader::new(&le_data);
+    let mut bebits = BigEndianReader::new(&be_data);
 
-    lebits.has_bits_remaining(64) == bebits.has_bits_remaining(64)
-        && (!lebits.has_bits_remaining(64)
-            || lebits.read_u64_unchecked().to_be() == bebits.read_u64_unchecked())
+    lebits.read_u64_unchecked() == bebits.read_u64_unchecked()
 }
 
 #[quickcheck]

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -1,12 +1,12 @@
 extern crate bitter;
 extern crate bitterv1;
 
-use bitter::{BigEndianBits, BitReader, LittleEndianBits};
+use bitter::{BigEndianReader, BitReader, LittleEndianReader};
 
 #[test]
 fn regression1() {
     let data = vec![0b0000_0010, 0b0011_1111, 0b1011_1100];
-    let mut bits = bitter::LittleEndianBits::new(data.as_slice());
+    let mut bits = bitter::LittleEndianReader::new(data.as_slice());
     let mut bitsv1 = bitterv1::BitGet::new(data.as_slice());
 
     assert_eq!(bits.read_u32_bits(3), bitsv1.read_u32_bits(3));
@@ -21,8 +21,8 @@ fn test_f32_endian() {
     let le_data = bits.to_le_bytes();
     let be_data = bits.to_be_bytes();
 
-    let mut lebits = LittleEndianBits::new(&le_data);
-    let mut bebits = BigEndianBits::new(&be_data);
+    let mut lebits = LittleEndianReader::new(&le_data);
+    let mut bebits = BigEndianReader::new(&be_data);
 
     assert_eq!(lebits.read_f32(), Some(12.5f32));
     assert_eq!(bebits.read_f32(), Some(12.5f32));
@@ -31,8 +31,8 @@ fn test_f32_endian() {
 #[test]
 fn read_byte_eq() {
     let data = vec![0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1];
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = BigEndianBits::new(data.as_slice());
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+    let mut bebits = BigEndianReader::new(data.as_slice());
 
     assert_eq!(lebits.read_u8(), bebits.read_u8());
     assert_eq!(lebits.read_u8(), bebits.read_u8());
@@ -52,8 +52,8 @@ fn read_byte_eq() {
 #[test]
 fn read_byte_eq2() {
     let data = vec![1, 0, 0, 0, 0, 0, 0, 0, 0];
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = BigEndianBits::new(data.as_slice());
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+    let mut bebits = BigEndianReader::new(data.as_slice());
 
     assert_eq!(lebits.read_u8(), bebits.read_u8());
     assert_eq!(lebits.read_u8(), bebits.read_u8());
@@ -70,7 +70,7 @@ fn read_byte_eq2() {
 #[test]
 fn read_byte_le_unchecked() {
     let data = vec![1, 0, 0, 0, 0, 0, 0, 0, 0];
-    let mut lebits = LittleEndianBits::new(data.as_slice());
+    let mut lebits = LittleEndianReader::new(data.as_slice());
 
     assert_eq!(lebits.read_u8_unchecked(), 1);
     assert_eq!(lebits.read_u8_unchecked(), 0);
@@ -88,7 +88,7 @@ fn read_byte_le_unchecked() {
 #[test]
 fn read_byte_be_unchecked() {
     let data = vec![1, 0, 0, 0, 0, 0, 0, 0, 0];
-    let mut bits = BigEndianBits::new(data.as_slice());
+    let mut bits = BigEndianReader::new(data.as_slice());
 
     assert_eq!(bits.read_u8_unchecked(), 1);
     assert_eq!(bits.read_u8_unchecked(), 0);
@@ -106,7 +106,7 @@ fn read_byte_be_unchecked() {
 #[test]
 fn read_byte_be() {
     let data = vec![1, 0, 0, 0, 0, 0, 0, 0, 0];
-    let mut bits = BigEndianBits::new(data.as_slice());
+    let mut bits = BigEndianReader::new(data.as_slice());
 
     assert_eq!(bits.read_u8(), Some(1));
     assert_eq!(bits.read_u8(), Some(0));
@@ -124,8 +124,8 @@ fn read_byte_be() {
 #[test]
 fn read_byte_eq_unchecked() {
     let data = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
-    let mut lebits = LittleEndianBits::new(data.as_slice());
-    let mut bebits = BigEndianBits::new(data.as_slice());
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+    let mut bebits = BigEndianReader::new(data.as_slice());
 
     assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
     assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
@@ -151,7 +151,7 @@ fn read_byte_eq_unchecked() {
 #[test]
 fn remaining_bits_le() {
     let data: &[u8] = &[0, 0, 0, 0, 0, 0, 0, 0, 0];
-    let mut lebits = LittleEndianBits::new(data);
+    let mut lebits = LittleEndianReader::new(data);
     assert!(lebits.has_bits_remaining(65));
     for _ in 0..65 {
         assert!(!lebits.read_bit().unwrap());
@@ -161,6 +161,6 @@ fn remaining_bits_le() {
 #[test]
 fn has_bits_remaining_bit_reads_test_case() {
     let data = &[0, 0, 0, 0, 0, 0, 0, 0];
-    let mut bits = LittleEndianBits::new(data);
+    let mut bits = LittleEndianReader::new(data);
     assert!((1..128).all(|_x| bits.has_bits_remaining(1) == bits.read_bit().is_some()))
 }

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -30,7 +30,7 @@ fn test_f32_endian() {
 
 #[test]
 fn read_byte_eq() {
-    let data = vec![0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+    let data = vec![0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1];
     let mut lebits = LittleEndianBits::new(data.as_slice());
     let mut bebits = BigEndianBits::new(data.as_slice());
 
@@ -65,6 +65,87 @@ fn read_byte_eq2() {
     assert_eq!(lebits.read_u8(), bebits.read_u8());
     assert_eq!(lebits.read_u8(), bebits.read_u8());
     assert_eq!(lebits.read_u8(), bebits.read_u8());
+}
+
+#[test]
+fn read_byte_le_unchecked() {
+    let data = vec![1, 0, 0, 0, 0, 0, 0, 0, 0];
+    let mut lebits = LittleEndianBits::new(data.as_slice());
+
+    assert_eq!(lebits.read_u8_unchecked(), 1);
+    assert_eq!(lebits.read_u8_unchecked(), 0);
+    assert_eq!(lebits.read_u8_unchecked(), 0);
+    assert_eq!(lebits.read_u8_unchecked(), 0);
+    assert_eq!(lebits.read_u8_unchecked(), 0);
+    assert_eq!(lebits.read_u8_unchecked(), 0);
+    assert_eq!(lebits.read_u8_unchecked(), 0);
+    assert_eq!(lebits.read_u8_unchecked(), 0);
+    assert_eq!(lebits.read_u8_unchecked(), 0);
+
+    assert!(lebits.is_empty());
+}
+
+#[test]
+fn read_byte_be_unchecked() {
+    let data = vec![1, 0, 0, 0, 0, 0, 0, 0, 0];
+    let mut bits = BigEndianBits::new(data.as_slice());
+
+    assert_eq!(bits.read_u8_unchecked(), 1);
+    assert_eq!(bits.read_u8_unchecked(), 0);
+    assert_eq!(bits.read_u8_unchecked(), 0);
+    assert_eq!(bits.read_u8_unchecked(), 0);
+    assert_eq!(bits.read_u8_unchecked(), 0);
+    assert_eq!(bits.read_u8_unchecked(), 0);
+    assert_eq!(bits.read_u8_unchecked(), 0);
+    assert_eq!(bits.read_u8_unchecked(), 0);
+    assert_eq!(bits.read_u8_unchecked(), 0);
+
+    assert!(bits.is_empty());
+}
+
+#[test]
+fn read_byte_be() {
+    let data = vec![1, 0, 0, 0, 0, 0, 0, 0, 0];
+    let mut bits = BigEndianBits::new(data.as_slice());
+
+    assert_eq!(bits.read_u8(), Some(1));
+    assert_eq!(bits.read_u8(), Some(0));
+    assert_eq!(bits.read_u8(), Some(0));
+    assert_eq!(bits.read_u8(), Some(0));
+    assert_eq!(bits.read_u8(), Some(0));
+    assert_eq!(bits.read_u8(), Some(0));
+    assert_eq!(bits.read_u8(), Some(0));
+    assert_eq!(bits.read_u8(), Some(0));
+    assert_eq!(bits.read_u8(), Some(0));
+
+    assert!(bits.is_empty());
+}
+
+#[test]
+fn read_byte_eq_unchecked() {
+    let data = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+    let mut lebits = LittleEndianBits::new(data.as_slice());
+    let mut bebits = BigEndianBits::new(data.as_slice());
+
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+    assert_eq!(lebits.read_u8_unchecked(), bebits.read_u8_unchecked());
+
+    assert!(lebits.is_empty());
+    assert!(bebits.is_empty());
 }
 
 #[test]

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -48,3 +48,18 @@ fn read_byte_eq() {
     assert_eq!(lebits.read_u8(), bebits.read_u8());
     assert_eq!(lebits.read_u8(), bebits.read_u8());
 }
+fn remaining_bits_le() {
+    let data: &[u8] = &[0, 0, 0, 0, 0, 0, 0, 0, 0];
+    let mut lebits = LittleEndianBits::new(data);
+    assert!(lebits.has_bits_remaining(65));
+    for _ in 0..65 {
+        assert!(!lebits.read_bit().unwrap());
+    }
+}
+
+#[test]
+fn has_bits_remaining_bit_reads_test_case() {
+    let data = &[0, 0, 0, 0, 0, 0, 0, 0];
+    let mut bits = LittleEndianBits::new(data);
+    assert!((1..128).all(|_x| bits.has_bits_remaining(1) == bits.read_bit().is_some()))
+}

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -1,10 +1,12 @@
 extern crate bitter;
 extern crate bitterv1;
 
+use bitter::BitOrder;
+
 #[test]
 fn regression1() {
     let data = vec![0b0000_0010, 0b0011_1111, 0b1011_1100];
-    let mut bits = bitter::BitGet::new(data.as_slice());
+    let mut bits = bitter::LittleEndianBits::new(data.as_slice());
     let mut bitsv1 = bitterv1::BitGet::new(data.as_slice());
 
     assert_eq!(bits.read_u32_bits(3), bitsv1.read_u32_bits(3));

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -48,6 +48,26 @@ fn read_byte_eq() {
     assert_eq!(lebits.read_u8(), bebits.read_u8());
     assert_eq!(lebits.read_u8(), bebits.read_u8());
 }
+
+#[test]
+fn read_byte_eq2() {
+    let data = vec![1, 0, 0, 0, 0, 0, 0, 0, 0];
+    let mut lebits = LittleEndianBits::new(data.as_slice());
+    let mut bebits = BigEndianBits::new(data.as_slice());
+
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+}
+
+#[test]
 fn remaining_bits_le() {
     let data: &[u8] = &[0, 0, 0, 0, 0, 0, 0, 0, 0];
     let mut lebits = LittleEndianBits::new(data);

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -1,7 +1,7 @@
 extern crate bitter;
 extern crate bitterv1;
 
-use bitter::{BigEndianBits, BitOrder, LittleEndianBits};
+use bitter::{BigEndianBits, BitReader, LittleEndianBits};
 
 #[test]
 fn regression1() {

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -1,7 +1,7 @@
 extern crate bitter;
 extern crate bitterv1;
 
-use bitter::BitOrder;
+use bitter::{BigEndianBits, BitOrder, LittleEndianBits};
 
 #[test]
 fn regression1() {
@@ -13,4 +13,17 @@ fn regression1() {
     assert_eq!(bits.read_u8(), bitsv1.read_u8());
     assert_eq!(bits.read_bit(), bitsv1.read_bit());
     assert_eq!(bits.read_u32_bits(13), bitsv1.read_u32_bits(13));
+}
+
+#[test]
+fn test_f32_endian() {
+    let bits = 0x41480000u32;
+    let le_data = bits.to_le_bytes();
+    let be_data = bits.to_be_bytes();
+
+    let mut lebits = LittleEndianBits::new(&le_data);
+    let mut bebits = BigEndianBits::new(&be_data);
+
+    assert_eq!(lebits.read_f32(), Some(12.5f32));
+    assert_eq!(bebits.read_f32(), Some(12.5f32));
 }

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -27,3 +27,24 @@ fn test_f32_endian() {
     assert_eq!(lebits.read_f32(), Some(12.5f32));
     assert_eq!(bebits.read_f32(), Some(12.5f32));
 }
+
+#[test]
+fn read_byte_eq() {
+    let data = vec![0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+    let mut lebits = LittleEndianBits::new(data.as_slice());
+    let mut bebits = BigEndianBits::new(data.as_slice());
+
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+    assert_eq!(lebits.read_u8(), bebits.read_u8());
+}


### PR DESCRIPTION
**Big breaking update**

- `BigGet` has been renamed to `LittleEndianReader` to better reflect its name in light of:
- Introduction of `BigEndianReader` and `NativeEndianReader` alias
- A trait, `BitReader` that is the new home for consuming bits like `read_u8`

Instead of writing:

```rust
use bitter::BitGet;
let mut bitter = BitGet::new(&[0xff, 0x04]);
assert_eq!(bitter.read_bit(), Some(true));
assert_eq!(bitter.read_u8(), Some(0x7f));
assert_eq!(bitter.read_u32_bits(7), Some(0x02));
```

One will now write:

```rust
use bitter::{BitReader, LittleEndianReader};
let mut bitter = LittleEndianReader::new(&[0xff, 0x04]);
assert_eq!(bitter.read_bit(), Some(true));
assert_eq!(bitter.read_u8(), Some(0x7f));
assert_eq!(bitter.read_u32_bits(7), Some(0x02));
```


Closes #8 