### PR TITLE
Implement two's complement for arbitrary sized bit widths

### DIFF
--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -362,3 +362,127 @@ fn read_be_bits_64_unchecked(x: u64) -> bool {
     let mut bebits = BigEndianReader::new(data.as_slice());
     bebits.read_bits_unchecked(64) == x
 }
+
+#[quickcheck]
+fn read_le_signed_bits(a: i8, b: i16, c: i32, d: i64) -> bool {
+    let mut data = Vec::new();
+    data.extend_from_slice(&(a.to_le_bytes()));
+    data.extend_from_slice(&(b.to_le_bytes()));
+    data.extend_from_slice(&(c.to_le_bytes()));
+    data.extend_from_slice(&(d.to_le_bytes()));
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+
+    lebits.read_signed_bits(8).map(|x| x as i8) == Some(a) &&
+    lebits.read_signed_bits(16).map(|x| x as i16) == Some(b) &&
+    lebits.read_signed_bits(32).map(|x| x as i32) == Some(c) &&
+    lebits.read_signed_bits(64).map(|x| x as i64) == Some(d)
+}
+
+#[quickcheck]
+fn read_le_signed_unchecked_bits(a: i8, b: i16, c: i32, d: i64) -> bool {
+    let mut data = Vec::new();
+    data.extend_from_slice(&(a.to_le_bytes()));
+    data.extend_from_slice(&(b.to_le_bytes()));
+    data.extend_from_slice(&(c.to_le_bytes()));
+    data.extend_from_slice(&(d.to_le_bytes()));
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+
+    lebits.read_signed_bits_unchecked(8) as i8 == a &&
+    lebits.read_signed_bits_unchecked(16) as i16 == b &&
+    lebits.read_signed_bits_unchecked(32) as i32 == c &&
+    lebits.read_signed_bits_unchecked(64) as i64 == d
+}
+
+#[quickcheck]
+fn read_le_signed_bits2(a: i8, b: i16, c: i32, d: i64) -> bool {
+    let mut data = Vec::new();
+    data.extend_from_slice(&(a.to_le_bytes()));
+    data.extend_from_slice(&(b.to_le_bytes()));
+    data.extend_from_slice(&(c.to_le_bytes()));
+    data.extend_from_slice(&(d.to_le_bytes()));
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+    let mut lebits2 = LittleEndianReader::new(data.as_slice());
+
+    lebits.read_signed_bits(8).map(|x| x as i8) == lebits2.read_i8() &&
+    lebits.read_signed_bits(16).map(|x| x as i16) == lebits2.read_i16() &&
+    lebits.read_signed_bits(32).map(|x| x as i32) == lebits2.read_i32() &&
+    lebits.read_signed_bits(64).map(|x| x as i64) == lebits2.read_i64()
+}
+
+#[quickcheck]
+fn read_le_signed_unchecked_bits2(a: i8, b: i16, c: i32, d: i64) -> bool {
+    let mut data = Vec::new();
+    data.extend_from_slice(&(a.to_le_bytes()));
+    data.extend_from_slice(&(b.to_le_bytes()));
+    data.extend_from_slice(&(c.to_le_bytes()));
+    data.extend_from_slice(&(d.to_le_bytes()));
+    let mut lebits = LittleEndianReader::new(data.as_slice());
+    let mut lebits2 = LittleEndianReader::new(data.as_slice());
+
+    lebits.read_signed_bits_unchecked(8) as i8 == lebits2.read_i8_unchecked() &&
+    lebits.read_signed_bits_unchecked(16) as i16 == lebits2.read_i16_unchecked() &&
+    lebits.read_signed_bits_unchecked(32) as i32 == lebits2.read_i32_unchecked() &&
+    lebits.read_signed_bits_unchecked(64) as i64 == lebits2.read_i64_unchecked()
+}
+
+#[quickcheck]
+fn read_be_signed_bits(a: i8, b: i16, c: i32, d: i64) -> bool {
+    let mut data = Vec::new();
+    data.extend_from_slice(&(a.to_be_bytes()));
+    data.extend_from_slice(&(b.to_be_bytes()));
+    data.extend_from_slice(&(c.to_be_bytes()));
+    data.extend_from_slice(&(d.to_be_bytes()));
+    let mut bebits = BigEndianReader::new(data.as_slice());
+
+    bebits.read_signed_bits(8).map(|x| x as i8) == Some(a) &&
+    bebits.read_signed_bits(16).map(|x| x as i16) == Some(b) &&
+    bebits.read_signed_bits(32).map(|x| x as i32) == Some(c) &&
+    bebits.read_signed_bits(64).map(|x| x as i64) == Some(d)
+}
+
+#[quickcheck]
+fn read_be_signed_unchecked_bits(a: i8, b: i16, c: i32, d: i64) -> bool {
+    let mut data = Vec::new();
+    data.extend_from_slice(&(a.to_be_bytes()));
+    data.extend_from_slice(&(b.to_be_bytes()));
+    data.extend_from_slice(&(c.to_be_bytes()));
+    data.extend_from_slice(&(d.to_be_bytes()));
+    let mut bebits = BigEndianReader::new(data.as_slice());
+
+    bebits.read_signed_bits_unchecked(8) as i8 == a &&
+    bebits.read_signed_bits_unchecked(16) as i16 == b &&
+    bebits.read_signed_bits_unchecked(32) as i32 == c &&
+    bebits.read_signed_bits_unchecked(64) as i64 == d
+}
+
+#[quickcheck]
+fn read_be_signed_bits2(a: i8, b: i16, c: i32, d: i64) -> bool {
+    let mut data = Vec::new();
+    data.extend_from_slice(&(a.to_be_bytes()));
+    data.extend_from_slice(&(b.to_be_bytes()));
+    data.extend_from_slice(&(c.to_be_bytes()));
+    data.extend_from_slice(&(d.to_be_bytes()));
+    let mut bebits = BigEndianReader::new(data.as_slice());
+    let mut bebits2 = BigEndianReader::new(data.as_slice());
+
+    bebits.read_signed_bits(8).map(|x| x as i8) == bebits2.read_i8() &&
+    bebits.read_signed_bits(16).map(|x| x as i16) == bebits2.read_i16() &&
+    bebits.read_signed_bits(32).map(|x| x as i32) == bebits2.read_i32() &&
+    bebits.read_signed_bits(64).map(|x| x as i64) == bebits2.read_i64()
+}
+
+#[quickcheck]
+fn read_be_signed_unchecked_bits2(a: i8, b: i16, c: i32, d: i64) -> bool {
+    let mut data = Vec::new();
+    data.extend_from_slice(&(a.to_be_bytes()));
+    data.extend_from_slice(&(b.to_be_bytes()));
+    data.extend_from_slice(&(c.to_be_bytes()));
+    data.extend_from_slice(&(d.to_be_bytes()));
+    let mut bebits = BigEndianReader::new(data.as_slice());
+    let mut bebits2 = BigEndianReader::new(data.as_slice());
+
+    bebits.read_signed_bits_unchecked(8) as i8 == bebits2.read_i8_unchecked() &&
+    bebits.read_signed_bits_unchecked(16) as i16 == bebits2.read_i16_unchecked() &&
+    bebits.read_signed_bits_unchecked(32) as i32 == bebits2.read_i32_unchecked() &&
+    bebits.read_signed_bits_unchecked(64) as i64 == bebits2.read_i64_unchecked()
+}


### PR DESCRIPTION
This is a breaking change. The following functions have been removed:

```
read_i32_bits
read_i32_bits_unchecked
```

These have been removed for two reasons:

- unsigned reads have transitioned to 64 bit return types
- The use cases for this function is extremely limited.

Expanding on the second point, the function name could be misleading. It
would be more intuitive that when the user requests 3 bits that are
signed that these three bits are treated an 3 bits of two's complement,
meaning that the top bit would make the result negative. To give an
example, if the next three bits are encountered:

```
111
```

Then the result should be -1. Arbitrarily wide two's complement support
had not been possible until today. This functionality is now exposed in
two new functions:

```
read_signed_bits
read_signed_bits_unchecked
```