### PR TITLE
replaced hackish casting with more idiomatic solution

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,7 +536,7 @@ pub const fn bit_width(input: u64) -> u32 {
 
 #[inline]
 fn bit_mask(bits: usize) -> u64 {
-    let mask = -1i64 as u64;
+    let mask = u64::MAX;
     let size = core::mem::size_of::<u64>() * 8;
     mask >> (size - bits)
 }
@@ -546,7 +546,7 @@ fn bit_mask_zero(bits: usize) -> u64 {
     if bits == 0 {
         0
     } else {
-        let mask = -1i64 as u64;
+        let mask = u64::MAX;
         let size = core::mem::size_of::<u64>() * 8;
         mask >> (size - bits)
     }


### PR DESCRIPTION
if you do:
```Rust
assert(-1i64 as u64 == u64::MAX);
```
It will pass and I would argue that u64::MAX is a more idiomatic way of doing this since it doesn't rely on a hackish casting between types.