### PR TITLE
Fixed LittleEndianReader example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -910,8 +910,8 @@ generate_bitter_end!(
     /// Reads bits in the little-endian format
     ///
     /// ```rust
-    /// use bitter::{BitReader, BigEndianReader};
-    /// let mut lebits = BigEndianReader::new(&[0b1000_0000]);
+    /// use bitter::{BitReader, LittleEndianReader};
+    /// let mut lebits = LittleEndianReader::new(&[0b0000_0001]);
     /// assert_eq!(lebits.read_bit(), Some(true));
     /// ```
     LittleEndianReader,


### PR DESCRIPTION
It looks like you forgot to switch BigEndian to LittleEndian when copying and pasting for the LittleEndianReader example