### PR TITLE
Convert internal state to slice instead of pointers

### DIFF
--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -7,7 +7,12 @@ use std::io::Read;
 #[inline(never)]
 fn read_data(data: &[u8]) -> Option<i64> {
     let mut reader = bitter::LittleEndianReader::new(data);
-    let result = reader.read_signed_bits(27)?;
+    let mut result = reader.read_signed_bits(27)?;
+    result += i64::from(reader.read_i8()?);
+
+    reader.refill_lookahead();
+    unsafe { reader.refill_lookahead_unchecked() }
+
     let mut buf = [0u8; 10];
     if !reader.read_bytes(&mut buf) {
         return None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,7 +490,7 @@ impl<'a, const LE: bool> BitterState<'a, LE> {
         debug_assert!(self.unbuffered_bytes() < 8);
         let mut result = [0u8; 8];
         let len = self.unbuffered_bytes();
-        result[..len].copy_from_slice(&self.data);
+        result[..len].copy_from_slice(self.data);
         let result = u64::from_ne_bytes(result);
         Self::which(result)
     }


### PR DESCRIPTION
When switching internal state to be based on a byte slice:

- There is some performance fluctuation
  - The biggest outlier observed across all runs is real-world-1/bitter-auto suffered a 5-10% hit
- Tons of unsafe removed (there's only one instance non-unchecked instance now that I can't fix without introducing a panic).