### PR TITLE
Resolving remaining pedantic clippy issues

### DIFF
--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -185,7 +185,7 @@ fn _test_bit_reads2<T: BitReader>(mut bitter: T, bits: u32) {
 
         let res = bitter.peek(chunk);
         bitter.consume(chunk);
-        bitter::sign_extend(res, len);
+        let _ = bitter::sign_extend(res, len);
     }
 }
 


### PR DESCRIPTION
The only change to public APIs is the annotation of `#[must_use]`, but I'm not considering this a breaking change as this would most likely reveal the presence of a bug.

I verified that the assembly did not change with the read_eof implementation (using `#[inline(never)]`). Amusingly, whitespace changed. I'm not sure why, but it doesn't seem like a problem.