### PR TITLE
Support bit reads of size zero

### DIFF
--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -12,6 +12,8 @@ fn read_data(data: &[u8]) -> Option<i64> {
 
     reader.refill_lookahead();
     unsafe { reader.refill_lookahead_unchecked() }
+    result += reader.peek(0) as i64;
+    reader.consume(0);
 
     let mut buf = [0u8; 10];
     if !reader.read_bytes(&mut buf) {


### PR DESCRIPTION
When reading a length prefixed value, that length could be zero. The current behavior when reading zero is to panic as the big endian reader would witness a right shift overflow.

This commit removes the restriction at the cost of an extra mask for big endian readers. This causes up to a 10% throughput penalty (with averages in the low single digits) for the big endian reader. This downside seems acceptable.