### PR TITLE
Relax peek/consume constraints with exposure of remaining lookahead bits

### DIFF
--- a/fuzz/fuzz_targets/fuzz_simple.rs
+++ b/fuzz/fuzz_targets/fuzz_simple.rs
@@ -1,6 +1,6 @@
 #![no_main]
+use bitter::{BigEndianReader, BitReader, LittleEndianReader};
 use libfuzzer_sys::fuzz_target;
-use bitter::{LittleEndianReader, BigEndianReader, BitReader};
 
 fuzz_target!(|data: &[u8]| {
     let size = LittleEndianReader::new(data).read_u32().unwrap_or(0);
@@ -27,16 +27,14 @@ fuzz_target!(|data: &[u8]| {
     assert!(bebits.is_empty());
 
     let mut bitter = LittleEndianReader::new(data);
-    let mut len = bitter.refill_lookahead();
     let mut i = 0;
-    while len != 0 {
-        let read = (i % 56 + 1) % len as u32 + 1;
+    while bitter.lookahead_bits() != 0 {
+        let read = (i % 56 + 1) % bitter.lookahead_bits() as u32 + 1;
         i += 1;
         bitter.peek(read);
         bitter.consume(read);
-        len -= read;
-        if len == 0 {
-            len = bitter.refill_lookahead();
+        if bitter.lookahead_bits() == 0 {
+            bitter.refill_lookahead();
         }
     }
 


### PR DESCRIPTION
This is a breaking change, but one that is hopefully understood.

Previously one would be unable to `peek` or `consume` more than `MAX_READ_BITS` at once even though it is possible for a given refill to support more than `MAX_READ_BITS`. This commit removes the constraint so that only the amount of bits in the lookahead buffer is the max for a given peek or consume. (This also could be worked around by compiling without debug assertions, but we don't talk about that).

Since the number of available bits in the lookahead buffer is already represented by the internal state `bit_count`, it made sense to drop the return value from `refill_lookahead` and add a new function `lookahead_bits` in case one wanted to know the number of available bits at any point in time.

Benchmarks have been updated to use this new technique.