### PR TITLE
Read bits supports up to 64 bit reads

### DIFF
--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -194,7 +194,7 @@ fn _test_read_bytes_equiv<T: BitReader>(mut bitter1: T, mut bitter2: T, buf_len:
     let mut buf1 = vec![0u8; usize::from(buf_len)];
     let mut buf2 = vec![0u8; usize::from(buf_len)];
 
-    let shift = shift as u32 % 57;
+    let shift = shift as u32 % 65;
     assert_eq!(bitter1.read_bits(shift), bitter2.read_bits(shift));
 
     if !bitter1.has_bits_remaining(buf1.len() * 8) {


### PR DESCRIPTION
Closes #38
Closes #43

Performance results: Similar same performance profiles at the micro and macro scales. There is a performance "regression" for reads above 56 bits, but since they weren't supported before, it's not something to sweat over.

So I'm happy with this. The previous bit read limit has been lifted without performance penalties.