### PR TITLE
Remove black_box in benchmarks in favor of accumulator

### DIFF
--- a/compare/benches/bench_bits.rs
+++ b/compare/benches/bench_bits.rs
@@ -3,7 +3,7 @@ use bitstream_io::{BitRead, BitReader as bio_br, LittleEndian};
 use bitter;
 use bitter::{BitReader, LittleEndianReader};
 use bitvec::{field::BitField, order::Lsb0, view::BitView};
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use std::io::Cursor;
 
 static DATA: [u8; 0x10_000] = [0; 0x10_000];
@@ -17,6 +17,7 @@ const ITER: u64 = 1000;
 // into here, but that seemed unfair.
 fn bit_reading<const N: u32, const UNCHECKED: bool, T: BitReader>(mut bitter: T, bits: u32) {
     let iterations = ITER / N as u64;
+    let mut result = 0;
     for _ in 0..iterations {
         if UNCHECKED {
             unsafe { bitter.refill_lookahead_unchecked() }
@@ -25,10 +26,11 @@ fn bit_reading<const N: u32, const UNCHECKED: bool, T: BitReader>(mut bitter: T,
         };
 
         for _ in 0..N {
-            black_box(bitter.peek(bits));
+            result |= bitter.peek(bits);
             bitter.consume(bits);
         }
     }
+    assert_eq!(result, 0);
 }
 
 fn bitting(c: &mut Criterion) {
@@ -41,26 +43,19 @@ fn bitting(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("bitter-auto", i), &i, |b, param| {
             b.iter(|| {
                 let mut bitter = LittleEndianReader::new(&DATA[..]);
-                bitter.read_bits(1);
-                if *param <= bitter::MAX_READ_BITS {
-                    for _ in 0..ITER {
-                        black_box(bitter.read_bits(*param));
-                    }
-                } else {
-                    for _ in 0..ITER {
-                        let lo = bitter.read_bits(bitter::MAX_READ_BITS).unwrap();
-                        let hi_bits = *param - bitter::MAX_READ_BITS;
-                        let hi = bitter.read_bits(hi_bits).unwrap();
-                        black_box((hi << bitter::MAX_READ_BITS) + lo);
-                    }
+                let mut result = bitter.read_bits(1).unwrap();
+                for _ in 0..ITER {
+                    result |= bitter.read_bits(*param).unwrap();
                 }
+                assert_eq!(result, 0);
             })
         });
 
         group.bench_with_input(BenchmarkId::new("bitter-manual", i), &i, |b, param| {
             b.iter(|| {
                 let mut bitter = LittleEndianReader::new(&DATA[..]);
-                bitter.read_bits(1);
+                bitter.refill_lookahead();
+                bitter.consume(1);
                 match *param {
                     1..=3 => bit_reading::<16, false, _>(bitter, *param),
                     4..=7 => bit_reading::<8, false, _>(bitter, *param),
@@ -68,27 +63,22 @@ fn bitting(c: &mut Criterion) {
                     15..=28 => bit_reading::<2, false, _>(bitter, *param),
                     29..=56 => bit_reading::<1, false, _>(bitter, *param),
                     x => {
+                        let mut result = 0;
                         for _ in 0..ITER {
-                            let lo_len = bitter.lookahead_bits();
-                            let lo = bitter.peek(lo_len);
-                            bitter.consume(lo_len);
-
                             bitter.refill_lookahead();
-                            let left = x - lo_len;
-                            let hi_len = bitter.lookahead_bits().min(left);
-                            let hi = bitter.peek(hi_len);
-                            bitter.consume(hi_len);
+                            let lo = bitter.peek(bitter::MAX_READ_BITS);
+                            bitter.consume(bitter::MAX_READ_BITS);
 
-                            if hi_len == left {
-                                black_box((hi << lo_len) + lo);
-                            } else {
-                                bitter.refill_lookahead();
-                                let left = x - lo_len - hi_len;
-                                let hi2 = bitter.peek(left);
-                                bitter.consume(left);
-                                black_box((hi2 << (lo_len + hi_len)) + (hi << lo_len) + lo);
-                            }
+                            let hi_bits = x - bitter::MAX_READ_BITS;
+                            bitter.refill_lookahead();
+
+                            let hi = bitter.peek(hi_bits);
+                            bitter.consume(hi_bits);
+
+                            let read = (hi << bitter::MAX_READ_BITS) + lo;
+                            result |= read;
                         }
+                        assert_eq!(result, 0);
                     }
                 }
             })
@@ -97,7 +87,8 @@ fn bitting(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("bitter-unchecked", i), &i, |b, param| {
             b.iter(|| {
                 let mut bitter = LittleEndianReader::new(&DATA[..]);
-                bitter.read_bits(1);
+                unsafe { bitter.refill_lookahead_unchecked() };
+                bitter.consume(1);
                 match *param {
                     1..=3 => bit_reading::<16, true, _>(bitter, *param),
                     4..=7 => bit_reading::<8, true, _>(bitter, *param),
@@ -105,27 +96,23 @@ fn bitting(c: &mut Criterion) {
                     15..=28 => bit_reading::<2, true, _>(bitter, *param),
                     29..=56 => bit_reading::<1, true, _>(bitter, *param),
                     x => {
+                        let mut result = 0;
                         for _ in 0..ITER {
-                            let lo_len = bitter.lookahead_bits();
-                            let lo = bitter.peek(lo_len);
-                            bitter.consume(lo_len);
+                            unsafe { bitter.refill_lookahead_unchecked() }
 
-                            unsafe { bitter.refill_lookahead_unchecked() };
-                            let left = x - lo_len;
-                            let hi_len = bitter.lookahead_bits().min(left);
-                            let hi = bitter.peek(hi_len);
-                            bitter.consume(hi_len);
+                            let lo = bitter.peek(bitter::MAX_READ_BITS);
+                            bitter.consume(bitter::MAX_READ_BITS);
 
-                            if hi_len == left {
-                                black_box((hi << lo_len) + lo);
-                            } else {
-                                unsafe { bitter.refill_lookahead_unchecked() };
-                                let left = x - lo_len - hi_len;
-                                let hi2 = bitter.peek(left);
-                                bitter.consume(left);
-                                black_box((hi2 << (lo_len + hi_len)) + (hi << lo_len) + lo);
-                            }
+                            let hi_bits = x - bitter::MAX_READ_BITS;
+                            unsafe { bitter.refill_lookahead_unchecked() }
+
+                            let hi = bitter.peek(hi_bits);
+                            bitter.consume(hi_bits);
+
+                            let read = (hi << bitter::MAX_READ_BITS) + lo;
+                            result |= read;
                         }
+                        assert_eq!(result, 0);
                     }
                 }
             })
@@ -134,10 +121,11 @@ fn bitting(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("bitreader", i), &i, |b, param| {
             b.iter(|| {
                 let mut bitter = BR::new(&DATA);
-                bitter.read_u32(1).unwrap();
+                let mut result = bitter.read_u64(1).unwrap();
                 for _ in 0..ITER {
-                    black_box(bitter.read_u64(*param as u8).unwrap());
+                    result |= bitter.read_u64(*param as u8).unwrap();
                 }
+                assert_eq!(result, 0);
             })
         });
 
@@ -146,10 +134,11 @@ fn bitting(c: &mut Criterion) {
                 let mut cursor = Cursor::new(&DATA[..]);
                 {
                     let mut bits = bio_br::endian(&mut cursor, LittleEndian);
-                    bits.read_bit().unwrap();
+                    let mut result = bits.read::<u64>(1).unwrap();
                     for _ in 0..ITER {
-                        black_box(bits.read::<u64>(*param as u32).unwrap());
+                        result |= bits.read::<u64>(*param as u32).unwrap();
                     }
+                    assert_eq!(result, 0);
                 }
             });
         });
@@ -158,11 +147,13 @@ fn bitting(c: &mut Criterion) {
             b.iter(|| {
                 let mut bits = DATA.view_bits::<Lsb0>();
                 bits = &bits[1..];
+                let mut result = 0;
                 for _ in 0..ITER {
                     let (curr, next) = bits.split_at(*param as usize);
-                    black_box(curr.load_le::<u64>());
+                    result |= curr.load_le::<u64>();
                     bits = next;
                 }
+                assert_eq!(result, 0);
             })
         });
 
@@ -171,27 +162,32 @@ fn bitting(c: &mut Criterion) {
                 let buffer = bitbuffer::BitReadBuffer::new(&DATA[..], bitbuffer::LittleEndian);
                 let mut stream = bitbuffer::BitReadStream::new(buffer);
                 stream.skip_bits(1).unwrap();
+                let mut result = 0;
                 for _ in 0..ITER {
-                    black_box(stream.read_int::<u64>(*param as usize).unwrap());
+                    result |= stream.read_int::<u64>(*param as usize).unwrap();
                 }
+                assert_eq!(result, 0);
             })
         });
 
         group.bench_with_input(BenchmarkId::new("bitcursor", i), &i, |b, param| {
             b.iter(|| {
                 let mut cursor = llvm_bitcursor::BitCursor::new(&DATA[..]);
-                cursor.read(1).unwrap();
+                let mut result = cursor.read(1).unwrap();
 
                 // bitcursor does not support 64 bit reads
                 if *param == 64 {
                     for _ in 0..ITER {
-                        black_box(cursor.read(63).unwrap() + (cursor.read(1).unwrap() << 63));
+                        result |= cursor.read(63).unwrap();
+                        result |= cursor.read(1).unwrap() << 63;
                     }
                 } else {
                     for _ in 0..ITER {
-                        black_box(cursor.read(*param as usize).unwrap());
+                        result |= cursor.read(*param as usize).unwrap();
                     }
                 }
+
+                assert_eq!(result, 0);
             })
         });
     }
@@ -208,55 +204,66 @@ fn real_world1(c: &mut Criterion) {
     group.bench_function("bitter-auto", |b| {
         b.iter(|| {
             let mut bits = LittleEndianReader::new(&DATA);
+            let mut result = 0;
             for _ in 0..ITER {
-                black_box(bits.read_bits(2));
-                black_box(bits.read_bits(18));
-                black_box(bits.read_bits(18));
-                black_box(bits.read_bits(18));
+                let a = bits.read_bits(2).unwrap();
+                let b = bits.read_bits(18).unwrap();
+                let c = bits.read_bits(18).unwrap();
+                let d = bits.read_bits(18).unwrap();
+                result |= a + b + c + d;
             }
+            assert_eq!(result, 0);
         })
     });
 
     group.bench_function("bitter-manual", |b| {
         b.iter(|| {
             let mut bits = LittleEndianReader::new(&DATA);
+            let mut result = 0;
             for _ in 0..ITER {
                 bits.refill_lookahead();
                 assert!(bits.lookahead_bits() >= bitter::MAX_READ_BITS);
 
-                black_box(bits.peek(2));
+                let a = bits.peek(2);
                 bits.consume(2);
 
-                black_box(bits.peek(18));
+                let b = bits.peek(18);
                 bits.consume(18);
 
-                black_box(bits.peek(18));
+                let c = bits.peek(18);
                 bits.consume(18);
 
-                black_box(bits.peek(18));
+                let d = bits.peek(18);
                 bits.consume(18);
+
+                result |= a + b + c + d;
             }
+            assert_eq!(result, 0);
         })
     });
 
     group.bench_function("bitter-unchecked", |b| {
         b.iter(|| {
             let mut bits = LittleEndianReader::new(&DATA);
+            let mut result = 0;
             for _ in 0..ITER {
                 unsafe { bits.refill_lookahead_unchecked() };
 
-                black_box(bits.peek(2));
+                let a = bits.peek(2);
                 bits.consume(2);
 
-                black_box(bits.peek(18));
+                let b = bits.peek(18);
                 bits.consume(18);
 
-                black_box(bits.peek(18));
+                let c = bits.peek(18);
                 bits.consume(18);
 
-                black_box(bits.peek(18));
+                let d = bits.peek(18);
                 bits.consume(18);
+
+                result |= a + b + c + d;
             }
+            assert_eq!(result, 0);
         })
     });
 
@@ -272,65 +279,74 @@ fn real_world2(c: &mut Criterion) {
     group.bench_function("bitter-auto", |b| {
         b.iter(|| {
             let mut bits = LittleEndianReader::new(&DATA);
+            let mut result = 0;
             for _ in 0..ITER {
-                black_box(bits.read_bits(4));
-                black_box(bits.read_bits(1));
-                black_box(bits.read_bits(19));
-                black_box(bits.read_bits(19));
-                black_box(bits.read_bits(19));
+                let a = bits.read_bits(4).unwrap();
+                let b = bits.read_bits(1).unwrap();
+                let c = bits.read_bits(19).unwrap();
+                let d = bits.read_bits(19).unwrap();
+                let e = bits.read_bits(19).unwrap();
+                result |= a + b + c + d + e;
             }
+            assert_eq!(result, 0);
         })
     });
 
     group.bench_function("bitter-manual", |b| {
         b.iter(|| {
             let mut bits = LittleEndianReader::new(&DATA);
+            let mut result = 0;
             for _ in 0..ITER {
                 bits.refill_lookahead();
                 assert!(bits.lookahead_bits() >= 24);
-                black_box(bits.peek(4));
+                let a = bits.peek(4);
                 bits.consume(4);
 
-                black_box(bits.peek(1));
+                let b = bits.peek(1);
                 bits.consume(1);
 
-                black_box(bits.peek(19));
+                let c = bits.peek(19);
                 bits.consume(19);
 
                 bits.refill_lookahead();
                 assert!(bits.lookahead_bits() > 36);
-                black_box(bits.peek(19));
+                let d = bits.peek(19);
                 bits.consume(19);
 
-                black_box(bits.peek(19));
+                let e = bits.peek(19);
                 bits.consume(19);
+                result |= a + b + c + d + e;
             }
+            assert_eq!(result, 0);
         })
     });
 
     group.bench_function("bitter-unchecked", |b| {
         b.iter(|| {
             let mut bits = LittleEndianReader::new(&DATA);
+            let mut result = 0;
             for _ in 0..ITER {
                 unsafe { bits.refill_lookahead_unchecked() };
 
-                black_box(bits.peek(4));
+                let a = bits.peek(4);
                 bits.consume(4);
 
-                black_box(bits.peek(1));
+                let b = bits.peek(1);
                 bits.consume(1);
 
-                black_box(bits.peek(19));
+                let c = bits.peek(19);
                 bits.consume(19);
 
                 unsafe { bits.refill_lookahead_unchecked() };
 
-                black_box(bits.peek(19));
+                let d = bits.peek(19);
                 bits.consume(19);
 
-                black_box(bits.peek(19));
+                let e = bits.peek(19);
                 bits.consume(19);
+                result |= a + b + c + d + e;
             }
+            assert_eq!(result, 0);
         })
     });
 
@@ -340,17 +356,19 @@ fn real_world2(c: &mut Criterion) {
 fn read_bytes(c: &mut Criterion) {
     let mut group = c.benchmark_group("read_bytes");
 
-    for i in &[5, 20, 80, 240, 960] {
-        let iterations = DATA.len() / *i;
+    for i in &[4, 8, 16, 80, 240, 960] {
+        let iterations = (DATA.len() / *i) - 1;
         group.throughput(Throughput::Bytes((iterations * *i) as u64));
 
         group.bench_with_input(BenchmarkId::new("aligned", i), &i, |b, param| {
             let mut buf = vec![0u8; **param];
             b.iter(|| {
                 let mut bitter = LittleEndianReader::new(&DATA[..]);
+                let mut result = true;
                 for _ in 0..iterations {
-                    assert!(black_box(bitter.read_bytes(&mut buf)));
+                    result &= bitter.read_bytes(&mut buf);
                 }
+                assert!(result);
             })
         });
 
@@ -359,9 +377,11 @@ fn read_bytes(c: &mut Criterion) {
             b.iter(|| {
                 let mut bitter = LittleEndianReader::new(&DATA[..]);
                 bitter.read_bit();
+                let mut result = true;
                 for _ in 0..iterations {
-                    assert!(black_box(bitter.read_bytes(&mut buf)));
+                    result &= bitter.read_bytes(&mut buf);
                 }
+                assert!(result);
             })
         });
     }
@@ -378,21 +398,25 @@ fn signed(c: &mut Criterion) {
     group.bench_function("auto", |b| {
         b.iter(|| {
             let mut bits = LittleEndianReader::new(&DATA[..]);
+            let mut result = 0;
             for _ in 0..ITER {
-                black_box(bits.read_signed_bits(bits_to_read));
+                result |= bits.read_signed_bits(bits_to_read).unwrap();
             }
+            assert_eq!(result, 0);
         })
     });
 
     group.bench_function("manual", |b| {
         b.iter(|| {
             let mut bits = LittleEndianReader::new(&DATA[..]);
+            let mut result = 0;
             for _ in 0..ITER {
                 let _len = bits.refill_lookahead();
                 let val = bits.peek(bits_to_read);
                 bits.consume(bits_to_read);
-                black_box(bitter::sign_extend(val, bits_to_read));
+                result |= bitter::sign_extend(val, bits_to_read);
             }
+            assert_eq!(result, 0);
         })
     });
 


### PR DESCRIPTION
When benchmarking bitter changes at macro level, I noticed it was not reflective of the benchmarking code within bitter. I believe a big part of that reason is due to the use of `black_box` preventing optimizations that are apparent in any practical usage.

An accumulator + assertion replaces `black_box` which should allow for all bit streams to stretch their proverbial legs.