### PR TITLE
Allow recovery of unconsumed data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       run: |
         rustup toolchain install nightly --component miri
         cargo miri setup
-        cargo miri test
+        MIRIFLAGS="-Zmiri-tree-borrows" cargo miri test
 
     - name: Compile fuzz
       if: matrix.build == 'nightly'


### PR DESCRIPTION
```rust
let mut bits = LittleEndianReader::new(&[0b1010_1010, 0b0101_0101, 0b1100_0011]);

// When byte-aligned, no partial bits
let remainder = bits.remainder();
assert_eq!(remainder.partial_bits(), 0);
assert_eq!(remainder.data(), &[0b1010_1010, 0b0101_0101, 0b1100_0011]);

// After reading 3 bits, we have 5 bits remaining in a partially read byte
assert_eq!(bits.read_bits(3), Some(0b010));
let remainder = bits.remainder();

assert_eq!(remainder.partial_bits(), 5);
assert_eq!(remainder.partial_byte(), 0b0001_0101);
assert_eq!(remainder.data(), &[0b0101_0101, 0b1100_0011]);
```

Closes #65

This did require enabling tree borrows in miri, otherwise it would have required a deeper architectural change (like keeping around the original data slice), and I wanted to avoid any possible impact to users who may not fall into the remainder use case.