### PR TITLE
Make Remainder use the correct lifetime

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ mod writer;
 pub use writer::*;
 
 /// Read bits in a given endian order
-pub trait BitReader {
+pub trait BitReader<'a> {
     /// Consume a bit and return if the bit was enabled
     ///
     /// ```rust
@@ -545,7 +545,7 @@ pub trait BitReader {
     /// assert_eq!(remainder.partial_byte(), 0b0001_0101);
     /// assert_eq!(remainder.data(), &[0b0101_0101, 0b1100_0011]);
     /// ```
-    fn remainder(&self) -> Remainder<'_>;
+    fn remainder(&self) -> Remainder<'a>;
 }
 
 const BYTE_WIDTH: usize = core::mem::size_of::<u64>();
@@ -716,7 +716,7 @@ macro_rules! gen_read {
     };
 }
 
-impl<const LE: bool> BitReader for BitterState<'_, LE> {
+impl<'a, const LE: bool> BitReader<'a> for BitterState<'a, LE> {
     gen_read!(read_u8, u8);
     gen_read!(read_i8, i8);
     gen_read!(read_u16, u16);
@@ -964,7 +964,7 @@ impl<const LE: bool> BitReader for BitterState<'_, LE> {
         self.bit_count % 8 == 0
     }
 
-    fn remainder(&self) -> Remainder<'_> {
+    fn remainder(&self) -> Remainder<'a> {
         // Calculate how many bits are not byte-aligned
         let unaligned_bits = self.bit_count % 8;
 
@@ -1066,7 +1066,7 @@ impl<'a> LittleEndianReader<'a> {
     }
 }
 
-impl BitReader for LittleEndianReader<'_> {
+impl<'a> BitReader<'a> for LittleEndianReader<'a> {
     #[inline]
     fn read_bit(&mut self) -> Option<bool> {
         self.0.read_bit()
@@ -1193,7 +1193,7 @@ impl BitReader for LittleEndianReader<'_> {
     }
 
     #[inline]
-    fn remainder(&self) -> Remainder<'_> {
+    fn remainder(&self) -> Remainder<'a> {
         self.0.remainder()
     }
 }
@@ -1217,7 +1217,7 @@ impl<'a> BigEndianReader<'a> {
     }
 }
 
-impl BitReader for BigEndianReader<'_> {
+impl<'a> BitReader<'a> for BigEndianReader<'a> {
     #[inline]
     fn read_bit(&mut self) -> Option<bool> {
         self.0.read_bit()
@@ -1344,7 +1344,7 @@ impl BitReader for BigEndianReader<'_> {
     }
 
     #[inline]
-    fn remainder(&self) -> Remainder<'_> {
+    fn remainder(&self) -> Remainder<'a> {
         self.0.remainder()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ mod writer;
 pub use writer::*;
 
 /// Read bits in a given endian order
-pub trait BitReader<'a> {
+pub trait BitReader {
     /// Consume a bit and return if the bit was enabled
     ///
     /// ```rust
@@ -545,7 +545,7 @@ pub trait BitReader<'a> {
     /// assert_eq!(remainder.partial_byte(), 0b0001_0101);
     /// assert_eq!(remainder.data(), &[0b0101_0101, 0b1100_0011]);
     /// ```
-    fn remainder(&self) -> Remainder<'a>;
+    fn remainder(&self) -> Remainder<'_>;
 }
 
 const BYTE_WIDTH: usize = core::mem::size_of::<u64>();
@@ -716,7 +716,7 @@ macro_rules! gen_read {
     };
 }
 
-impl<'a, const LE: bool> BitReader<'a> for BitterState<'a, LE> {
+impl<const LE: bool> BitReader for BitterState<'_, LE> {
     gen_read!(read_u8, u8);
     gen_read!(read_i8, i8);
     gen_read!(read_u16, u16);
@@ -964,7 +964,7 @@ impl<'a, const LE: bool> BitReader<'a> for BitterState<'a, LE> {
         self.bit_count % 8 == 0
     }
 
-    fn remainder(&self) -> Remainder<'a> {
+    fn remainder(&self) -> Remainder<'_> {
         // Calculate how many bits are not byte-aligned
         let unaligned_bits = self.bit_count % 8;
 
@@ -1066,7 +1066,7 @@ impl<'a> LittleEndianReader<'a> {
     }
 }
 
-impl<'a> BitReader<'a> for LittleEndianReader<'a> {
+impl BitReader for LittleEndianReader<'_> {
     #[inline]
     fn read_bit(&mut self) -> Option<bool> {
         self.0.read_bit()
@@ -1193,7 +1193,7 @@ impl<'a> BitReader<'a> for LittleEndianReader<'a> {
     }
 
     #[inline]
-    fn remainder(&self) -> Remainder<'a> {
+    fn remainder(&self) -> Remainder<'_> {
         self.0.remainder()
     }
 }
@@ -1217,7 +1217,7 @@ impl<'a> BigEndianReader<'a> {
     }
 }
 
-impl<'a> BitReader<'a> for BigEndianReader<'a> {
+impl BitReader for BigEndianReader<'_> {
     #[inline]
     fn read_bit(&mut self) -> Option<bool> {
         self.0.read_bit()
@@ -1344,7 +1344,7 @@ impl<'a> BitReader<'a> for BigEndianReader<'a> {
     }
 
     #[inline]
-    fn remainder(&self) -> Remainder<'a> {
+    fn remainder(&self) -> Remainder<'_> {
         self.0.remainder()
     }
 }

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -494,3 +494,16 @@ fn read_ergonomics(i8: i8, u8: u8, i16: i16, u16: u16, i32: i32, u32: u32, i64: 
         (ff64.is_nan() && bebits.read_f64().unwrap().is_nan()) || bebits.read_f64() == Some(ff64)
     );
 }
+
+#[test]
+fn remainder_lifetime() {
+    fn helper<'a>(reader: &LittleEndianReader<'a>) -> bitter::Remainder<'a> {
+        reader.remainder()
+    }
+
+    // The whole point of this test is to fail at compile time if the
+    // remainder() function doesn't return the slice with the same
+    // lifetime as the underlying data.
+    let reader = LittleEndianReader::new(&[]);
+    helper(&reader);
+}

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -2,7 +2,7 @@ use bitter::{BigEndianReader, BitReader, LittleEndianReader};
 use quickcheck::TestResult;
 use quickcheck_macros::quickcheck;
 
-fn _test_bit_reads_auto<'a, T: BitReader<'a>>(mut bitter: T, data: &[u8]) {
+fn _test_bit_reads_auto<T: BitReader>(mut bitter: T, data: &[u8]) {
     assert!(bitter.has_bits_remaining(data.len() * 8));
     assert!(!bitter.has_bits_remaining(data.len() * 8 + 1));
     assert_eq!(bitter.read_bits(1), Some(0));
@@ -190,7 +190,7 @@ fn test_read_bytes_large(mut data: Vec<u8>, buf_len: u8) {
     assert_eq!(buf[74], 0b1100_0000);
 }
 
-fn _test_read_bytes_equiv<'a, T: BitReader<'a>>(mut bitter1: T, mut bitter2: T, buf_len: u8, shift: u8) {
+fn _test_read_bytes_equiv<T: BitReader>(mut bitter1: T, mut bitter2: T, buf_len: u8, shift: u8) {
     let mut buf1 = vec![0u8; usize::from(buf_len)];
     let mut buf2 = vec![0u8; usize::from(buf_len)];
 
@@ -252,7 +252,7 @@ fn test_bit_reads(data: Vec<u8>) {
     }
 }
 
-fn _test_bit_reads2<'a, T: BitReader<'a>>(mut bitter: T, bits: u32) {
+fn _test_bit_reads2<T: BitReader>(mut bitter: T, bits: u32) {
     let chunk = bits % 64 + 1;
     while bitter.has_bits_remaining(chunk as usize) {
         let mut chunk_remaining = chunk;
@@ -357,7 +357,7 @@ fn read_byte_alternate(data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn has_bits_remaining_bit_reads_ends(reads: u8, data: Vec<u8>) -> bool {
-    fn test_fn<'a, B: BitReader<'a>>(bits: &mut B, reads: u8) -> bool {
+    fn test_fn<B: BitReader>(bits: &mut B, reads: u8) -> bool {
         let mut result = true;
         if bits.has_bits_remaining(usize::from(reads)) {
             for _ in 0..reads {

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -2,7 +2,7 @@ use bitter::{BigEndianReader, BitReader, LittleEndianReader};
 use quickcheck::TestResult;
 use quickcheck_macros::quickcheck;
 
-fn _test_bit_reads_auto<T: BitReader>(mut bitter: T, data: &[u8]) {
+fn _test_bit_reads_auto<'a, T: BitReader<'a>>(mut bitter: T, data: &[u8]) {
     assert!(bitter.has_bits_remaining(data.len() * 8));
     assert!(!bitter.has_bits_remaining(data.len() * 8 + 1));
     assert_eq!(bitter.read_bits(1), Some(0));
@@ -190,7 +190,7 @@ fn test_read_bytes_large(mut data: Vec<u8>, buf_len: u8) {
     assert_eq!(buf[74], 0b1100_0000);
 }
 
-fn _test_read_bytes_equiv<T: BitReader>(mut bitter1: T, mut bitter2: T, buf_len: u8, shift: u8) {
+fn _test_read_bytes_equiv<'a, T: BitReader<'a>>(mut bitter1: T, mut bitter2: T, buf_len: u8, shift: u8) {
     let mut buf1 = vec![0u8; usize::from(buf_len)];
     let mut buf2 = vec![0u8; usize::from(buf_len)];
 
@@ -252,7 +252,7 @@ fn test_bit_reads(data: Vec<u8>) {
     }
 }
 
-fn _test_bit_reads2<T: BitReader>(mut bitter: T, bits: u32) {
+fn _test_bit_reads2<'a, T: BitReader<'a>>(mut bitter: T, bits: u32) {
     let chunk = bits % 64 + 1;
     while bitter.has_bits_remaining(chunk as usize) {
         let mut chunk_remaining = chunk;
@@ -357,7 +357,7 @@ fn read_byte_alternate(data: Vec<u8>) -> bool {
 
 #[quickcheck]
 fn has_bits_remaining_bit_reads_ends(reads: u8, data: Vec<u8>) -> bool {
-    fn test_fn<B: BitReader>(bits: &mut B, reads: u8) -> bool {
+    fn test_fn<'a, B: BitReader<'a>>(bits: &mut B, reads: u8) -> bool {
         let mut result = true;
         if bits.has_bits_remaining(usize::from(reads)) {
             for _ in 0..reads {

--- a/tests/properties.rs
+++ b/tests/properties.rs
@@ -497,13 +497,19 @@ fn read_ergonomics(i8: i8, u8: u8, i16: i16, u16: u16, i32: i32, u32: u32, i64: 
 
 #[test]
 fn remainder_lifetime() {
-    fn helper<'a>(reader: &LittleEndianReader<'a>) -> bitter::Remainder<'a> {
+    fn helper_le<'a>(reader: &LittleEndianReader<'a>) -> bitter::Remainder<'a> {
+        reader.remainder()
+    }
+
+    fn helper_be<'a>(reader: &BigEndianReader<'a>) -> bitter::Remainder<'a> {
         reader.remainder()
     }
 
     // The whole point of this test is to fail at compile time if the
     // remainder() function doesn't return the slice with the same
     // lifetime as the underlying data.
-    let reader = LittleEndianReader::new(&[]);
-    helper(&reader);
+    let le = LittleEndianReader::new(&[]);
+    helper_le(&le);
+    let be = BigEndianReader::new(&[]);
+    helper_be(&be);
 }


### PR DESCRIPTION
The slice returned by the `remainder()` function currently inherits the lifetime of the `BitReader` itself rather than the underlying data being read. I just stumbled across this while trying to port some of my code to your crate:

```rs
pub fn read_bytes<'a>(reader: &mut LittleEndianReader<'a>) -> io::Result<&'a [u8]> {
    let len = read_string_length(reader)?;
    if len != 0 {
        align(reader)?;

        let data = reader.remainder().data();
        let (buf, rem) = data
            .split_at_checked(len)
            .ok_or_else(|| ...)?;
        *reader = LittleEndianReader::new(rem);

        Ok(buf)
    } else {
        Ok(&[])
    }
}
```

This is a breaking change though as the `BitReader` trait needs to be made aware of the data slice lifetime.